### PR TITLE
fix: console shows current value upon expanding

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -799,8 +799,7 @@ function calculateCalendar() {
     tempSlots.clear()
     tempTasks.clear()
     tempTaskRelations.clear()
-    repository.saveDatabase()
-    if (tempTasks.length != 0) {
+    if (tempTasks.data.length != 0) {
         console.error("tempTasks not empty")
     }
     makeTempTasksFromExistingGoals()


### PR DESCRIPTION
Was mistakenly assuming the collection was not clearing since console.log showed values upon expanding.
The log showed length of 0 so that was confusing. Browser console does not remember historic state for expansion!