### PR TITLE
Modify cypress test

### DIFF
--- a/cypress/integration/home-page.test.js
+++ b/cypress/integration/home-page.test.js
@@ -24,6 +24,6 @@ describe("Basic Tests Home Page", () => {
         cy.get('[alt="Book Icon"]').should("be.visible");
     });
     it("user choice panel for language choice should work", () => {
-        cy.contains("Choose your preferred Language");
+        cy.get('*[class^="right-panel-font"]').should("be.visible");
     });
 });


### PR DESCRIPTION
The cypress test was failing in the latest commits, this was because of adding translations to the landing page. 
(The landing page detects the browser's default language and if it is among the translations then the page gets translated into that language, else English is set as the fallback language for now)