### PR TITLE
Remove page reloads from the code

### DIFF
--- a/src/components/404page/NotFoundPage.jsx
+++ b/src/components/404page/NotFoundPage.jsx
@@ -32,7 +32,6 @@ export function NotFoundPage() {
                 }
               onClick={() => {
                 navigate('/Home');
-                window.location.reload(false);
               }}
             >
               Home

--- a/src/components/dashboard/HeaderDashboard.jsx
+++ b/src/components/dashboard/HeaderDashboard.jsx
@@ -28,7 +28,6 @@ export function HeaderDashboard() {
           className="zinzen-logo-nav-dashboard"
           onClick={() => {
             navigate('/Home');
-            window.location.reload(false);
           }}
         />
         {darkModeStatus ? (
@@ -39,7 +38,6 @@ export function HeaderDashboard() {
             className="zinzen-text-logo-nav-dashboard"
             onClick={() => {
               navigate('/Home');
-              window.location.reload(false);
             }}
           />
         ) : (
@@ -50,7 +48,6 @@ export function HeaderDashboard() {
             className="zinzen-text-logo-nav-dashboard"
             onClick={() => {
               navigate('/Home');
-              window.location.reload(false);
             }}
           />
         )}

--- a/src/components/dashboard/UserChoiceDashboard.jsx
+++ b/src/components/dashboard/UserChoiceDashboard.jsx
@@ -49,7 +49,6 @@ export function UserChoiceDashboard() {
                         }
             onClick={() => {
               navigate('/Home/MyGoals');
-              window.location.reload(false);
             }}
           >
             {darkModeStatus ? (
@@ -88,7 +87,6 @@ export function UserChoiceDashboard() {
                         }
             onClick={() => {
               navigate('/Home/AddFeelings');
-              window.location.reload(false);
             }}
           >
             {darkModeStatus ? (
@@ -130,7 +128,6 @@ export function UserChoiceDashboard() {
                         }
             onClick={() => {
               navigate('');
-              window.location.reload(false);
             }}
           >
             {truncateContent(t('explore'))}
@@ -147,7 +144,6 @@ export function UserChoiceDashboard() {
                         }
             onClick={() => {
               navigate('/Home/ZinZen');
-              window.location.reload(false);
             }}
           >
             {truncateContent(t('zinzen'))}

--- a/src/components/landingpage/Header.jsx
+++ b/src/components/landingpage/Header.jsx
@@ -19,7 +19,6 @@ export function Header() {
         className="zinzen-logo-nav-landing-page"
         onClick={() => {
           navigate('/');
-          window.location.reload(false);
         }}
       />
       <img

--- a/src/components/languagechoices/LangItem.jsx
+++ b/src/components/languagechoices/LangItem.jsx
@@ -15,7 +15,6 @@ export function LangItem({ lang }) {
     setIsLanguageChosen(true);
     i18n.changeLanguage(langId);
     localStorage.setItem('language', JSON.stringify(langId));
-    window.location.reload(false);
   };
 
   return (

--- a/src/components/themechoicepage/ThemesChoice.jsx
+++ b/src/components/themechoicepage/ThemesChoice.jsx
@@ -20,7 +20,6 @@ export function ThemesChoice() {
           setIsThemeChosen(true);
           localStorage.setItem('theme', 'light');
           navigate('/Home');
-          window.location.reload(false);
         }}
       >
         <img
@@ -39,7 +38,6 @@ export function ThemesChoice() {
           setIsThemeChosen(true);
           localStorage.setItem('theme', 'dark');
           navigate('/Home');
-          window.location.reload(false);
         }}
       >
         <img src={ThemeDark} alt="Dark Theme" className="themechoice" />


### PR DESCRIPTION
Resolves #248 

This was such a stupid fix. I searched around a lot for what could be the cause of these reloads since the very reason for using ReactJS is to have SPA functionality and so the app shouldn't reload on route changes. Then I looked into the HMR of ViteJS and tried a few things but couldn't find any resources about it since there is no way this should happen at all.

Finally, when going through the code one last time I saw a wild `window.location.reload(false);` and then on doing a global search found out that there were around 10 of these at all the places where you would click somewhere to change the page. Removing them fixed the problem, felt so dumb after finding that out 😆 