### PR TITLE
added Pull Request from fork actions triggers

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: Cypress
-on: [push]
+on:
+  push:
+  pull_request: [opened, edited, ready_for_review]
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,7 +1,8 @@
 name: Cypress
 on:
   push:
-  pull_request: [opened, edited, ready_for_review]
+  pull_request:
+    types: [opened, edited, ready_for_review]
 
 jobs:
   cypress-run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,8 @@
 name: ESLint
 on:
   push:
-  pull_request: [opened, edited, ready_for_review]
+  pull_request:
+    types: [opened, edited, ready_for_review]
 
 jobs:
   eslint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: ESLint
-on: [push]
+on:
+  push:
+  pull_request: [opened, edited, ready_for_review]
+
 jobs:
   eslint:
     name: runner / eslint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ jobs:
   eslint:
     name: runner / eslint
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-eslint@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   eslint:
     name: runner / eslint
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-eslint@v1

--- a/.github/workflows/tslint.yml
+++ b/.github/workflows/tslint.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tsc:
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     name: Check typescript
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/tslint.yml
+++ b/.github/workflows/tslint.yml
@@ -1,5 +1,7 @@
 name: TSLint
-on: [push]
+on:
+  push:
+  pull_request: [opened, edited, ready_for_review]
 
 jobs:
   tsc:

--- a/.github/workflows/tslint.yml
+++ b/.github/workflows/tslint.yml
@@ -1,7 +1,8 @@
 name: TSLint
 on:
   push:
-  pull_request: [opened, edited, ready_for_review]
+  pull_request:
+    types: [opened, edited, ready_for_review]
 
 jobs:
   tsc:

--- a/.github/workflows/tslint.yml
+++ b/.github/workflows/tslint.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   tsc:
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     name: Check typescript
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
As can be seen in PR #311 the GitHub Actions don't get triggered.
This is because the PR comes from a forked repo  
  => not pushing to the ZinZen repo  
  => not triggering 'push' event on ZinZen repo
  => not triggering GitHub Actions.

I added a trigger for pull_request: [opened, edited, ready_for_review]