### PR TITLE
Integration in MyTimePage: Duration + Width Normalization + DummyTasks (with Timestamp)

### DIFF
--- a/src/pages/MyTimePage/MyTimePage.scss
+++ b/src/pages/MyTimePage/MyTimePage.scss
@@ -40,7 +40,6 @@
 
 .MyTime_colorPalette {
     display: flex;
-    background-color: gray;
 }
     .MyTime_colorPalette:first-child{
         border-radius: 2px 0px 0px 2px;

--- a/src/pages/MyTimePage/MyTimePage.scss
+++ b/src/pages/MyTimePage/MyTimePage.scss
@@ -40,6 +40,7 @@
 
 .MyTime_colorPalette {
     display: flex;
+    background-color: gray;
 }
     .MyTime_colorPalette:first-child{
         border-radius: 2px 0px 0px 2px;

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -11,6 +11,8 @@ import "./MyTimePage.scss";
 
 export const MyTimePage = () => {
   const [tmpTasks, setTmpTasks] = useState<GoalItem[]>([]);
+  const [goalOfMaxDuration, setGoalOfMaxDuration] = useState(0);
+  const [maxDurationOfUnplanned, setMaxDurationOfUnplanned] = useState(0);
   const today = new Date();
   today.setDate(today.getDate() + 1);
 
@@ -18,6 +20,7 @@ export const MyTimePage = () => {
 
   const getDayComponent = (day: string) => {
     let colorIndex = -1;
+    console.log(goalOfMaxDuration, maxDurationOfUnplanned);
     return (
       <div key={`day-${day}`} className="MyTime_day">
         <div className="MyTime_navRow">
@@ -41,7 +44,7 @@ export const MyTimePage = () => {
               <div
                 key={`task-${task.id}`}
                 style={{
-                  width: `${task.duration * 4.15}%`, // "10%",
+                  width: `${task.duration * 4.17}%`, // "10%",
                   height: "10px",
                   backgroundColor: `${task.title === "Unplaned" ? "gray" : darkrooms[colorIndex]}`
                 }}
@@ -56,15 +59,16 @@ export const MyTimePage = () => {
 
   useEffect(() => {
     (async () => {
-      const random = (min: number, max: number) => Math.floor(Math.random() * (max - min)) + min;
+      // const random = (min: number, max: number) => Math.floor(Math.random() * (max - min)) + min;
       const createDummyGoals = async () => {
         console.log("wait");
         const dummyNames: string[] = ["Unplaned", "Gym", "Study", "Unplaned", "Shopping", "Code Reviews", "Unplaned", "Algo Practice"];
-        dummyNames.map(async (goalName: string) => {
+        const dummyDurations : number[] = [4, 3, 1, 2, 3, 2, 6, 3];
+        dummyNames.map(async (goalName, index) => {
           const dummyGoal = createGoal(
             goalName,
             true,
-            goalName === "Unplaned" ? random(2, 5) : random(1, 3),
+            dummyDurations[index],
             null,
             null,
             0,
@@ -74,12 +78,27 @@ export const MyTimePage = () => {
           return id;
         });
       };
-      let goals: GoalItem[] = await getActiveGoals();
-      if (goals.length === 0) {
+      const getTasks = async () => {
+        const goals: GoalItem[] = await getActiveGoals();
+        let GMD = 0;
+        let MDU = 0;
+        goals.map((goal) => {
+          if (goal.title === "Unplaned" && MDU < goal.duration) {
+            MDU = goal.duration;
+          } else if (GMD < goal.duration) GMD = goal.duration;
+          return null;
+        });
+        setGoalOfMaxDuration(GMD);
+        setMaxDurationOfUnplanned(MDU);
+        return goals;
+      };
+      let tasks: GoalItem[] = await getActiveGoals();
+      if (tasks.length === 0) {
         await createDummyGoals();
-        goals = await getActiveGoals();
       }
-      setTmpTasks([...goals]);
+      tasks = await getTasks();
+
+      setTmpTasks([...tasks]);
     })();
   }, []);
 

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -38,13 +38,13 @@ export const MyTimePage = () => {
         </div>
         <div className="MyTime_colorPalette">
           {tmpTasks.map((task) => {
-            console.log(task);
+            const colorWidth = task.duration * 4.17;
             colorIndex = (colorIndex === darkrooms.length - 1) ? 0 : colorIndex + 1;
             return (
               <div
                 key={`task-${task.id}`}
                 style={{
-                  width: `${task.duration * 4.17}%`, // "10%",
+                  width: `${colorWidth}%`, // "10%",
                   height: "10px",
                   backgroundColor: `${task.title === "Unplaned" ? "gray" : darkrooms[colorIndex]}`
                 }}
@@ -61,7 +61,6 @@ export const MyTimePage = () => {
     (async () => {
       // const random = (min: number, max: number) => Math.floor(Math.random() * (max - min)) + min;
       const createDummyGoals = async () => {
-        console.log("wait");
         const dummyNames: string[] = ["Unplaned", "Gym", "Study", "Unplaned", "Shopping", "Code Reviews", "Unplaned", "Algo Practice"];
         const dummyDurations : number[] = [4, 3, 1, 2, 3, 2, 6, 3];
         dummyNames.map(async (goalName, index) => {

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -61,21 +61,21 @@ export const MyTimePage = () => {
               const unpColorWidth = getColorWidth(true, unplannedDurations[index]);
               return index === 0 ? (
                 <>
-                  {getColorComponent(`U-${day}-${index}`, unpColorWidth, "gray")}
+                  {getColorComponent(`U-${day}-${index}`, unpColorWidth, "lightgray")}
                   {getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex])}
                 </>
               )
                 : (
                   <>
                     {getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex])}
-                    {getColorComponent(`U-${day}-${index}`, unpColorWidth, "gray")}
+                    {getColorComponent(`U-${day}-${index}`, unpColorWidth, "lightgray")}
                   </>
                 );
             }
             return (getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex]));
           })}
           {unplannedIndices.slice(-1)[0] + 1 === tmpTasks.length ?
-            getColorComponent(`U-${day}-${-1}`, getColorWidth(true, unplannedDurations.slice(-1)[0]), "gray")
+            getColorComponent(`U-${day}-${-1}`, getColorWidth(true, unplannedDurations.slice(-1)[0]), "lightgray")
             : null}
         </div>
       </div>

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-key */
 import React, { useEffect, useState } from "react";
 import { Container, Row } from "react-bootstrap";
 import { ChevronRight } from "react-bootstrap-icons";
@@ -39,7 +38,7 @@ export const MyTimePage = () => {
     <div
       key={`task-${id}`}
       style={{
-        width: `${colorWidth}%`, // "10%",
+        width: `${colorWidth}%`,
         height: "10px",
         backgroundColor: `${color}`
       }}
@@ -75,7 +74,6 @@ export const MyTimePage = () => {
             const colorWidth = getColorWidth(false, task.duration);
             colorIndex = (colorIndex === darkrooms.length - 1) ? 0 : colorIndex + 1;
             if (unplannedIndices.includes(index)) {
-              // console.log("y", index);
               const unpColorWidth = getColorWidth(true, unplannedDurations[unplannedIndices.indexOf(index)]);
               if (index === 0) {
                 return (
@@ -101,13 +99,11 @@ export const MyTimePage = () => {
 
   useEffect(() => {
     (async () => {
-      // const random = (min: number, max: number) => Math.floor(Math.random() * (max - min)) + min;
       const createDummyGoals = async () => {
         let start = 0;
         let end = 0;
 
         const dummyNames: string[] = ["Unplanned", "Gym", "Study", "Unplanned", "Shopping", "Code Reviews", "Unplanned", "Algo Practice"];
-        // const dummyNames: string[] = ["Gym", "Study", "Shopping", "Code Reviews", "Algo Practice"];
         const dummyDurations : number[] = [4, 3, 1, 2, 3, 2, 6, 3];
         dummyNames.map(async (goalName, index) => {
           end = start + dummyDurations[index];
@@ -115,7 +111,6 @@ export const MyTimePage = () => {
             start = end;
             return null;
           }
-          // console.log("added");
           const dummyGoal = createGoal(
             goalName,
             true,
@@ -139,9 +134,7 @@ export const MyTimePage = () => {
         const unplannedInd :number[] = [];
         const unplannedDur :number[] = [];
         goals.map((goal, index) => {
-          // console.log(prev, goal.start);
           const diff = getDiffInHours(goal.start ? goal.start : new Date(), prev);
-          // console.log(index, diff);
           prev = new Date(goal.finish ? goal.finish : new Date());
           if (diff > 0) {
             unplannedInd.push(index - 1);
@@ -156,7 +149,6 @@ export const MyTimePage = () => {
         setUnplannedIndices([...unplannedInd]);
         setGoalOfMaxDuration(GMD);
         setMaxDurationOfUnplanned(MDU);
-        console.log(unplannedInd,unplannedDur);
         return goals;
       };
       let tasks: GoalItem[] = await getActiveGoals();

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -25,7 +25,7 @@ export const MyTimePage = () => {
   const darkrooms = ["#443027", "#9C4663", "#2B517B", "#612854"];
 
   const getColorWidth = (unplanned: boolean, duration: number) => {
-    if (toggle) return (duration * 4.17);
+    if (!toggle) return (duration * 4.17);
     let colorWidth = 0;
     if (unplanned && duration > goalOfMaxDuration) {
       colorWidth = (goalOfMaxDuration + 1) * 4.17;
@@ -75,25 +75,25 @@ export const MyTimePage = () => {
             const colorWidth = getColorWidth(false, task.duration);
             colorIndex = (colorIndex === darkrooms.length - 1) ? 0 : colorIndex + 1;
             if (unplannedIndices.includes(index)) {
-              const unpColorWidth = getColorWidth(true, unplannedDurations[index]);
-              return index === 0 ? (
-                <>
-                  {getColorComponent(`U-${day}-${index}`, unpColorWidth, "lightgray")}
-                  {getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex])}
-                </>
-              )
-                : (
+              // console.log("y", index);
+              const unpColorWidth = getColorWidth(true, unplannedDurations[unplannedIndices.indexOf(index)]);
+              if (index === 0) {
+                return (
                   <>
-                    {getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex])}
                     {getColorComponent(`U-${day}-${index}`, unpColorWidth, "lightgray")}
+                    {getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex])}
                   </>
                 );
+              }
+              return (
+                <>
+                  {getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex])}
+                  {getColorComponent(`U-${day}-${index}`, unpColorWidth, "lightgray")}
+                </>
+              );
             }
             return (getColorComponent(`task-${day}-${task.id}`, colorWidth, darkrooms[colorIndex]));
           })}
-          {unplannedIndices.slice(-1)[0] + 1 === tmpTasks.length ?
-            getColorComponent(`U-${day}-${-1}`, getColorWidth(true, unplannedDurations.slice(-1)[0]), "lightgray")
-            : null}
         </div>
       </div>
     );
@@ -115,7 +115,7 @@ export const MyTimePage = () => {
             start = end;
             return null;
           }
-          console.log("added");
+          // console.log("added");
           const dummyGoal = createGoal(
             goalName,
             true,
@@ -139,23 +139,24 @@ export const MyTimePage = () => {
         const unplannedInd :number[] = [];
         const unplannedDur :number[] = [];
         goals.map((goal, index) => {
-          console.log(prev, goal.start);
+          // console.log(prev, goal.start);
           const diff = getDiffInHours(goal.start ? goal.start : new Date(), prev);
-          console.log(index, diff);
+          // console.log(index, diff);
           prev = new Date(goal.finish ? goal.finish : new Date());
           if (diff > 0) {
-            unplannedInd.push(index);
+            unplannedInd.push(index - 1);
             unplannedDur.push(diff);
             MDU = MDU < diff ? diff : MDU;
           }
           if (GMD < goal.duration) GMD = goal.duration;
           return null;
         });
+        unplannedInd[0] = unplannedInd[0] === -1 ? 0 : unplannedInd[0];
         setUnplannedDurations([...unplannedDur]);
         setUnplannedIndices([...unplannedInd]);
         setGoalOfMaxDuration(GMD);
         setMaxDurationOfUnplanned(MDU);
-        console.log(unplannedInd);
+        console.log(unplannedInd,unplannedDur);
         return goals;
       };
       let tasks: GoalItem[] = await getActiveGoals();
@@ -178,7 +179,9 @@ export const MyTimePage = () => {
       <div className="slide MyTime_container">
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <h1 id="MyTime_title">My Time</h1>
-          <button style={{ fontSize: "1.52rem", background: "transparent" }} type="button" onClick={() => setToggle(!toggle)}>Normalize</button>
+          <button style={{ fontSize: "1.52rem", background: "transparent", padding: "0% 2%" }} type="button" onClick={() => setToggle(!toggle)}>
+            {`Normalize ${toggle ? "on" : "off"}`}
+          </button>
         </div>
         <div id="MyTime_days_container">
           {getDayComponent("Today")}

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-key */
 import React, { useEffect, useState } from "react";
 import { Container, Row } from "react-bootstrap";
 import { ChevronRight } from "react-bootstrap-icons";
@@ -15,6 +16,7 @@ export const MyTimePage = () => {
   const [maxDurationOfUnplanned, setMaxDurationOfUnplanned] = useState(0);
   const [unplannedIndices, setUnplannedIndices] = useState<number[]>([]);
   const [unplannedDurations, setUnplannedDurations] = useState<number[]>([]);
+  const [showTasks, setShowTasks] = useState(false);
   const today = new Date();
   today.setDate(today.getDate() + 1);
 
@@ -40,6 +42,15 @@ export const MyTimePage = () => {
       }}
     />
   );
+  const displayTasks = () => (
+    <div>
+      {tmpTasks.map((task) => (
+        <h3>
+          {`${task.title} ${task.start?.toLocaleTimeString()} - ${task.finish?.toLocaleTimeString()}`}
+        </h3>
+      ))}
+    </div>
+  );
   const getDayComponent = (day: string) => {
     let colorIndex = -1;
     return (
@@ -49,6 +60,9 @@ export const MyTimePage = () => {
           <button
             className="MyTime-expand-btw"
             type="button"
+            onClick={() => {
+              setShowTasks(!showTasks);
+            }}
           >
             <div> <ChevronRight /> </div>
           </button>
@@ -138,7 +152,7 @@ export const MyTimePage = () => {
         setUnplannedIndices([...unplannedInd]);
         setGoalOfMaxDuration(GMD);
         setMaxDurationOfUnplanned(MDU);
-        console.log(unplannedInd)
+        console.log(unplannedInd);
         return goals;
       };
       let tasks: GoalItem[] = await getActiveGoals();
@@ -162,6 +176,9 @@ export const MyTimePage = () => {
         <h1 id="MyTime_title">My Time</h1>
         <div id="MyTime_days_container">
           {getDayComponent("Today")}
+          {
+          showTasks ? displayTasks() : null
+          }
           {getDayComponent("Tomorrow")}
           {
             [...Array(5).keys()].map(() => {

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 import { Container, Row } from "react-bootstrap";
 import { ChevronRight } from "react-bootstrap-icons";
@@ -10,40 +10,49 @@ import { GoalItem } from "@src/models/GoalItem";
 import "./MyTimePage.scss";
 
 export const MyTimePage = () => {
+  const [tmpTasks, setTmpTasks] = useState<GoalItem[]>([]);
   const today = new Date();
   today.setDate(today.getDate() + 1);
 
-  const darkrooms = ["#443027", "#9C4663", "#646464", "#2B517B", " #612854"];
+  const darkrooms = ["#443027", "#9C4663", "#2B517B", "#612854"];
 
-  const getDayComponent = (day: string) => (
-    <div className="MyTime_day">
-      <div className="MyTime_navRow">
-        <h3 className="MyTime_dayTitle">
-          {day}
-        </h3>
-        <button
-          className="MyTime-expand-btw"
-          type="button"
-        >
-          <div>
-            <ChevronRight />
-          </div>
-        </button>
+  const getDayComponent = (day: string) => {
+    let colorIndex = -1;
+    return (
+      <div key={`day-${day}`} className="MyTime_day">
+        <div className="MyTime_navRow">
+          <h3 className="MyTime_dayTitle">
+            {day}
+          </h3>
+          <button
+            className="MyTime-expand-btw"
+            type="button"
+          >
+            <div>
+              <ChevronRight />
+            </div>
+          </button>
+        </div>
+        <div className="MyTime_colorPalette">
+          {tmpTasks.map((task) => {
+            console.log(task);
+            colorIndex = (colorIndex === darkrooms.length - 1) ? 0 : colorIndex + 1;
+            return (
+              <div
+                key={`task-${task.id}`}
+                style={{
+                  width: `${task.duration * 4.15}%`, // "10%",
+                  height: "10px",
+                  backgroundColor: `${darkrooms[colorIndex]}`
+                }}
+              />
+            );
+          }
+          )}
+        </div>
       </div>
-      <div className="MyTime_colorPalette">
-        {[...Array(10).keys()].map((i) => (
-          <div
-            key={`task-${i}`}
-            style={{
-              width: "10%",
-              height: "10px",
-              backgroundColor: `${darkrooms[Math.floor(Math.random() * darkrooms.length)]}`
-            }}
-          />
-        ))}
-      </div>
-    </div>
-  );
+    );
+  };
 
   useEffect(() => {
     (async () => {
@@ -65,8 +74,12 @@ export const MyTimePage = () => {
           return id;
         });
       };
-      const goals: GoalItem[] = await getActiveGoals();
-      if (goals.length === 0) { await createDummyGoals(); }
+      let goals: GoalItem[] = await getActiveGoals();
+      if (goals.length === 0) {
+        await createDummyGoals();
+        goals = await getActiveGoals();
+      }
+      setTmpTasks([...goals]);
     })();
   }, []);
 

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -17,12 +17,15 @@ export const MyTimePage = () => {
   const [unplannedIndices, setUnplannedIndices] = useState<number[]>([]);
   const [unplannedDurations, setUnplannedDurations] = useState<number[]>([]);
   const [showTasks, setShowTasks] = useState(false);
+  const [toggle, setToggle] = useState(false);
+
   const today = new Date();
   today.setDate(today.getDate() + 1);
 
   const darkrooms = ["#443027", "#9C4663", "#2B517B", "#612854"];
 
   const getColorWidth = (unplanned: boolean, duration: number) => {
+    if (toggle) return (duration * 4.17);
     let colorWidth = 0;
     if (unplanned && duration > goalOfMaxDuration) {
       colorWidth = (goalOfMaxDuration + 1) * 4.17;
@@ -173,7 +176,10 @@ export const MyTimePage = () => {
         </Row>
       </Container>
       <div className="slide MyTime_container">
-        <h1 id="MyTime_title">My Time</h1>
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <h1 id="MyTime_title">My Time</h1>
+          <button style={{ fontSize: "1.52rem", background: "transparent" }} type="button" onClick={() => setToggle(!toggle)}>Normalize</button>
+        </div>
         <div id="MyTime_days_container">
           {getDayComponent("Today")}
           {

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -20,7 +20,6 @@ export const MyTimePage = () => {
 
   const getDayComponent = (day: string) => {
     let colorIndex = -1;
-    console.log(goalOfMaxDuration, maxDurationOfUnplanned);
     return (
       <div key={`day-${day}`} className="MyTime_day">
         <div className="MyTime_navRow">
@@ -38,8 +37,13 @@ export const MyTimePage = () => {
         </div>
         <div className="MyTime_colorPalette">
           {tmpTasks.map((task) => {
-            const colorWidth = task.duration * 4.17;
+            let colorWidth = 0;
             colorIndex = (colorIndex === darkrooms.length - 1) ? 0 : colorIndex + 1;
+            if (task.title === "Unplaned" && task.duration > goalOfMaxDuration) {
+              colorWidth = (goalOfMaxDuration + 1) * 4.17;
+            } else {
+              colorWidth = (task.duration * 4.17) + (maxDurationOfUnplanned - 1 - goalOfMaxDuration) * 4.17;
+            }
             return (
               <div
                 key={`task-${task.id}`}

--- a/src/pages/MyTimePage/MyTimePage.tsx
+++ b/src/pages/MyTimePage/MyTimePage.tsx
@@ -43,7 +43,7 @@ export const MyTimePage = () => {
                 style={{
                   width: `${task.duration * 4.15}%`, // "10%",
                   height: "10px",
-                  backgroundColor: `${darkrooms[colorIndex]}`
+                  backgroundColor: `${task.title === "Unplaned" ? "gray" : darkrooms[colorIndex]}`
                 }}
               />
             );
@@ -59,12 +59,12 @@ export const MyTimePage = () => {
       const random = (min: number, max: number) => Math.floor(Math.random() * (max - min)) + min;
       const createDummyGoals = async () => {
         console.log("wait");
-        const dummyNames: string[] = ["Walk", "Gym", "Study", "Shopping", "Nap", "Code Reviews", "Algo Practice"];
+        const dummyNames: string[] = ["Unplaned", "Gym", "Study", "Unplaned", "Shopping", "Code Reviews", "Unplaned", "Algo Practice"];
         dummyNames.map(async (goalName: string) => {
           const dummyGoal = createGoal(
             goalName,
             true,
-            random(1, 4),
+            goalName === "Unplaned" ? random(2, 5) : random(1, 3),
             null,
             null,
             0,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,3 +23,9 @@ export const getDates = (startDate: Date, stopDate: Date) => {
   }
   return dateArray;
 };
+
+export const getDiffInHours = (date1 : Date, date2: Date) => {
+  let diff = date1.getTime() - date2.getTime();
+  diff = Math.round(Math.abs(diff / 36e5));
+  return diff;
+};


### PR DESCRIPTION
Resolves #477
Resolves #481 
Resolves #490 

Upgrade in solution for #476

To make review easy ( for #481 ) I've made a commit with a message **checkpoint: Preview**. Consider the vercel deployment preview link after this commit to compare and differentiate with the last deployment link ( **checkpoint: Final Preview** )

1. For testing purpose, i have created the function for populating dummy tasks. Creating a collection and set of apis for MyTimePage has to be discussed so till then to keep the code complexity minimum i m using the goals as tasks.
2. The "Unplaned" word represents the user have no tasks in that particular duration i.e. **unplanned time**. Rest other dummy names represent the task name like "Gym" -> "Go to Gym" 
3. Reason for introducing the point 2 is to have a record of the entire day i.e. 24hrs
4. Now since we have the record of all day, there are two things we can find out. **First,** we will know the task that is of the highest duration. **Second,** we can find how much max unplanned time appeared btw two consecutive tasks. 
5. Once we have the MaxUnplannedTime we will take it certain amount and will distribute it among the width of other goals.
**NOTE:** All of the normalization stuff is done to normalize the width of colors (CSS) not the actual duration of tasks.     