### PR TITLE
bug for light and dark color text translations resolved

### DIFF
--- a/src/pages/ThemeChoice/ThemeChoice.tsx
+++ b/src/pages/ThemeChoice/ThemeChoice.tsx
@@ -30,7 +30,7 @@ export const ThemeChoice = () => {
           navigate("/QueryZinZen");
         }}
       >
-        Light colors
+        {t("Light colors")}
       </button>
       <button
         type="button"
@@ -43,7 +43,7 @@ export const ThemeChoice = () => {
           setDarkModeStatus(true);
         }}
       >
-        Dark colors
+        {t("Dark colors")}
       </button>
     </div>
   );

--- a/src/translations/de/translation.json
+++ b/src/translations/de/translation.json
@@ -82,5 +82,7 @@
   "search":"Suche",
   "privacy":"Privatsphäre",
   "sharedwithme": "Mit mir geteilt",
-  "collaborationinvites": "Zusammenarbeit lädt ein"
+  "collaborationinvites": "Zusammenarbeit lädt ein",
+  "Light colors" : "Helle Farben",
+  "Dark colors" : "Dunkle Farben"
 }

--- a/src/translations/en/translation.json
+++ b/src/translations/en/translation.json
@@ -92,6 +92,8 @@
   "privacy":"Privacy",
   "search": "Search",
   "sharedwithme": "Shared with me",
-  "collaborationinvites": "Collaboration invites"
+  "collaborationinvites": "Collaboration invites",
+  "Light colors" : "Light colors",
+  "Dark colors" : "Dark colors"
 
 }

--- a/src/translations/es/translation.json
+++ b/src/translations/es/translation.json
@@ -92,5 +92,7 @@
   "search":"Búsqueda",
   "privacy":"Privacidad",
   "sharedwithme": "Comparte conmigo",
-  "collaborationinvites": "Invitaciones de colaboración"
+  "collaborationinvites": "Invitaciones de colaboración",
+  "Light colors" : "Colores claros",
+  "Dark colors" : "Colores oscuros"
 }

--- a/src/translations/fr/translation.json
+++ b/src/translations/fr/translation.json
@@ -92,5 +92,7 @@
   "privacy":"Confidentialité",
   "search": "Chercher",
   "sharedwithme": "Partagé avec moi",
-  "collaborationinvites": "Invitations à collaborer"
+  "collaborationinvites": "Invitations à collaborer",
+  "Light colors" : "Couleurs claires",
+  "Dark colors" : "Couleurs sombres"
 }

--- a/src/translations/hi/translation.json
+++ b/src/translations/hi/translation.json
@@ -92,6 +92,7 @@
   "privacy":"निजता",
   "search": "खोज",
   "sharedwithme": "मेरे साथ बांटा",
-  "collaborationinvites": "सहयोग आमंत्रित"
-  
+  "collaborationinvites": "सहयोग आमंत्रित",
+  "Light colors" : "हल्के रंग",
+  "Dark colors" : "गहरे रंग"
 }

--- a/src/translations/nl/translation.json
+++ b/src/translations/nl/translation.json
@@ -92,5 +92,7 @@
   "search":"Zoek",
   "privacy":"Privacy",
   "sharedwithme": "Gedeeld met mij",
-  "collaborationinvites": "Samenwerkingsuitnodigingen"
+  "collaborationinvites": "Samenwerkingsuitnodigingen",
+  "Light colors" : "Lichte kleuren",
+  "Dark colors" : "Donkere kleuren"
 }

--- a/src/translations/pt/translation.json
+++ b/src/translations/pt/translation.json
@@ -76,5 +76,7 @@
   "search":"Procurar",
   "privacy":"Privacidade",
   "sharedwithme": "Compartilhou comigo",
-  "collaborationinvites": "Convites de colaboração"
+  "collaborationinvites": "Convites de colaboração",
+  "Light colors" : "Cores claras",
+  "Dark colors" : "Cores escuras"
 }


### PR DESCRIPTION
Hi Tushar, the bug that revolved around "Light colors" and "Dark colors" text translation on Theme Choice page has been resolved.
To resolve it, I first read the complete details about the bug. Then, as mentioned that the text was hard coded, so I concluded that this was not a bug but just that maybe the translator function wasn't yet implemented on the page.
I looked on the pages where the translation was working fine, so I just read more about it on the i18 documentation page. And accordingly translated both the strings in the necessary languages and copied those translations over the translation pages that are already present. 
After this, I just called the translator function with these strings as parameters in them. This worked well and it was translating it for all languages perfectly.
Please have a look and do the needful.