### PR TITLE
add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,13 @@
+Resolves #
+
+### Standard stuff
+- [x] if no issue is referenced, my changes are simple and summarized in max three sentences here.  
+If not please make an issue - so need for change is validated  
+- [x] I'll be patient as I understand responses can take days.  
+- [x] I have formatted according to project guidelines.
+- [x] I have not introduced any new failing lints or tests.
+- [x] I tried to apply the [clean code guidelines](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29).
+
+### Change summary  
+Optional; only for small changes without an issue.  
+Max three sentences.  

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,8 +1,9 @@
 Resolves #
 
 ### Standard stuff
-- [x] if no issue is referenced, my changes are simple and summarized in max three sentences here.  
-If not please make an issue - so need for change is validated  
+- [x] The PR title is of form 'issue_title #issue_number'
+- [x] If no issue is referenced, my changes are simple and summarized in title - and in max three sentences in the description.  
+If not please make an issue - so need for change is validated.  
 - [x] I'll be patient as I understand responses can take days.  
 - [x] I have formatted according to project guidelines.
 - [x] I have not introduced any new failing lints or tests.


### PR DESCRIPTION
Rather than detailing everything in a separate contributor file that no one reads, I propose to include a standard checklist in the PR. You'll ignore this if you're submitting PRs more often, but it will naturally appear in the PR flow for first-timers.  

Can you add a specification for the formatting style we follow?  

The formatting comment can be removed once we resolve #891  