### PR TITLE
fix: [#1192] Added accordion prop to Collapse

### DIFF
--- a/src/common/Accordion.tsx
+++ b/src/common/Accordion.tsx
@@ -10,6 +10,7 @@ const ZAccordion : React.FC<ZAccordionProps> = ({ panels, style, showCount, defa
     expandIcon={({ isActive }) => (<img alt="zinzen about" className={`${isActive ? "chevronDown" : "chevronRight"} theme-icon`} src={chevronLeftIcon} />)}
     defaultActiveKey={defaultActiveKey}
     style={style}
+    accordion
   >
     {panels.map((panel, index) => (
       <Collapse.Panel


### PR DESCRIPTION
### **Scope of change**
- Added the `accordion` to make sure only one Panel is visible at a time.

### **Screenshots**
![image](https://user-images.githubusercontent.com/87971509/236677956-788a8fcc-6ef9-44a1-82cb-16665c0feaf7.png)

### **Notes**
This closes #1192 