### PR TITLE
Show 100% done if there are no tasks

### DIFF
--- a/src/components/MyTimeComponents/ColorBands.tsx
+++ b/src/components/MyTimeComponents/ColorBands.tsx
@@ -55,7 +55,7 @@ const ColorBands: React.FC<IColorBands> = ({ list, tasksStatus, day, active }) =
       {active && day === "Today" && (
         <>
           <div className="task-progress">
-            <p>{`${Math.floor((dayCompleted / dayTotal) * 100)}% done`}</p>
+          <p>{`${dayTotal > 0 ? Math.floor((dayCompleted / dayTotal) * 100) : 100}% done`}</p>
           </div>
           <div className={`MyTime_colorPalette ${active ? "active" : ""}`}>
             {[...completed, {


### PR DESCRIPTION
PR to close #1374

### **Changes**
- Add a ternary operator to show done percentage if there are any tasks that day and show 100 percent if there aren't

### **Comment**
I am wondering if instead of showing "100% done" if there are no tasks added that day it would be better to show "No tasks today" instead, or something like that.