### PR TITLE
Navigate to goal hierarchy root with Goals button

### DIFF
--- a/src/components/BottomNavbar/BottomNavbar.tsx
+++ b/src/components/BottomNavbar/BottomNavbar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
+import { goalsHistory } from "@src/store/GoalsState";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import backIcon from "@assets/images/backIcon.svg";
@@ -26,6 +27,7 @@ const BottomNavbar = ({ title }: { title: string }) => {
   const [darkModeStatus, setDarkModeStatus] = useRecoilState(darkModeState);
 
   const currentPage = window.location.pathname.split("/")[1];
+  const subGoalHistory = useRecoilValue(goalsHistory);
 
   const themeChange = (nav: -1 | 1) => {
     let choice = theme[darkModeStatus ? "dark" : "light"] + nav;
@@ -49,7 +51,13 @@ const BottomNavbar = ({ title }: { title: string }) => {
       if (to === "MyTime") {
         if (currentPage !== "") navigate("/", { state: newLocationState });
       } else if (to === "MyGoals") {
-        if (currentPage !== "MyGoals") navigate("/MyGoals", { state: newLocationState });
+        if (currentPage !== "MyGoals") {
+          navigate("/MyGoals", { state: newLocationState })
+        } else {
+          if (subGoalHistory.length > 0) {
+            window.history.go(-subGoalHistory.length)
+          }
+        };
       } else if (currentPage !== "MyJournal") {
         navigate("/MyJournal", { state: newLocationState });
       }


### PR DESCRIPTION
PR to close #1381 

### **Changes**
- Import `{goalsHistory}`
- Add an `if else` statement to go back to goal hierarchy root

### **Comment**
In the else statement I'm checking if goalsHistory length is not 0, otherwise clicking the Goals button reloads the entire page. It feels a bit strange but I'm not too familiar with Recoil.js. If there's a way around it or a better way to do it, I don't see it at the moment. If there isn't then good :)