### PR TITLE
options btn added with icon

### DIFF
--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.scss
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.scss
@@ -72,6 +72,10 @@
   .action-btn {
     margin-top: 0;
     padding: 10px 24px;
+
+    &.options-btn{
+      margin-left: 10px;
+    }
   }
   .datepicker {
     text-align: left;

--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -87,9 +87,12 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
     setSelectedTag("");
   };
 
-  const handleFieldChange = (key: string, value: string) => {
+  const handleFieldChange = (key: string, value: string) => { 
     if (key === "duration") {
       setTags({ ...tags, duration: value });
+      if(value === ""){
+        setShowAllSettings(false);
+      }
       return;
     }
     if (isPerSelected) {
@@ -360,9 +363,6 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
-        <button type="button" style={{ position: "absolute", top: 29, right: 24 }} className="ordinary-element" onClick={() => setShowAllSettings(!showAllSettings)}>
-          <img src={expandIcon} alt="maximize edit window" style={{ width: 18, height: 18 }} />
-        </button>
       </div>
       <div style={{ padding: "0 24px" }}>
         <div style={{ display: "flex", gap: 15, padding: "12px 0" }}>
@@ -468,6 +468,11 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
         <button type="button" className="action-btn" onClick={handleSave}>
           {t(`${action} Goal`)}
         </button>
+        {tags.duration &&
+          <button type="button" className="action-btn options-btn" onClick={() => setShowAllSettings(!showAllSettings)}>
+            Options   <img src={expandIcon} alt="maximize edit window" style={{width: 12, height: 12 }} />
+          </button>
+        }
       </div>
     </Modal>
   );


### PR DESCRIPTION
Resolves #1362 

I have removed expanded icon button from title and added besides the "**Create Goal**" button , and named it "**Options**" with expanded icon.

The options button **won't show up until duration is added to create a goal**. I tried to keep the options button disabled until  the duration is not added, but the disabled button color is same as active button color which can create confusion. 

Settings section gets auto closed if the duration is removed.

Following are the screenshots.

Old UI
![Old UI](https://github.com/tijlleenders/ZinZen/assets/62180559/12d048e2-7171-44f7-b7e9-cf0eff045d5a)

Options button won't show until duration is added.
![New UI 1](https://github.com/tijlleenders/ZinZen/assets/62180559/1094aa5b-7b83-4718-9483-a24a4b11d591)

Options button visible when duration is added.
![New UI 2](https://github.com/tijlleenders/ZinZen/assets/62180559/d2be840a-0fa8-455d-923f-c91635a5ebe4)
