### PR TITLE
Create goal input hours fix

### DIFF
--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -39,7 +39,7 @@ const CustomInput: React.FC<ICustomInputProps> = ({ placeholder, value, handleCh
 );
 
 const roundOffHours = (hrsValue: string) => {
-  return String(Math.max(Math.round(Number(hrsValue)), 1));
+  return hrsValue === "" ? "" : String(Math.max(Math.round(Number(hrsValue)), 0));
 };
 
 const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalItem }) => {
@@ -254,8 +254,6 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
               <CustomInput
                 value={tags.perDay.split("-")[0]}
                 handleChange={(value: string) => {
-                  console.log(tags.perDay);
-
                   setTags({ ...tags, perDay: `${roundOffHours(value)}-${tags.perDay.split("-")[1]}` });
                 }}
                 style={{}}

--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -39,7 +39,7 @@ const CustomInput: React.FC<ICustomInputProps> = ({ placeholder, value, handleCh
 );
 
 const roundOffHours = (hrsValue: string) => {
-  return String(Math.min(Math.max(Math.round(Number(hrsValue)), 1), 24));
+  return String(Math.max(Math.round(Number(hrsValue)), 1));
 };
 
 const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalItem }) => {

--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -38,6 +38,10 @@ const CustomInput: React.FC<ICustomInputProps> = ({ placeholder, value, handleCh
   />
 );
 
+const roundOffHours = (hrsValue: string) => {
+  return String(Math.min(Math.max(Math.round(Number(hrsValue)), 1), 24));
+};
+
 const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalItem }) => {
   const { t } = useTranslation();
   const theme = useRecoilValue(themeState);
@@ -192,7 +196,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
               <CustomInput
                 value={tags.duration}
                 handleChange={(value: string) => {
-                  setTags({ ...tags, duration: value });
+                  setTags({ ...tags, duration: roundOffHours(value) });
                 }}
                 style={{}}
               />
@@ -230,7 +234,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
             <CustomInput
               value={tags.afterTime}
               handleChange={(value: string) => {
-                setTags({ ...tags, afterTime: value });
+                setTags({ ...tags, afterTime: roundOffHours(value) });
               }}
               style={{}}
             />
@@ -238,7 +242,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
             <CustomInput
               value={tags.beforeTime}
               handleChange={(value: string) => {
-                setTags({ ...tags, beforeTime: value });
+                setTags({ ...tags, beforeTime: roundOffHours(value) });
               }}
               style={{}}
             />
@@ -250,7 +254,9 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
               <CustomInput
                 value={tags.perDay.split("-")[0]}
                 handleChange={(value: string) => {
-                  setTags({ ...tags, perDay: `${value}-${tags.perDay.split("-")[1]}` });
+                  console.log(tags.perDay);
+
+                  setTags({ ...tags, perDay: `${roundOffHours(value)}-${tags.perDay.split("-")[1]}` });
                 }}
                 style={{}}
                 placeholder="min"
@@ -260,7 +266,9 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
                 <CustomInput
                   value={tags.perDay.split("-")[1]}
                   handleChange={(value: string) => {
-                    setTags({ ...tags, perDay: `${tags.perDay.split("-")[0]}-${value}` });
+                    console.log(`${tags.perDay.split("-")[0]}-${value}`);
+
+                    setTags({ ...tags, perDay: `${tags.perDay.split("-")[0]}-${roundOffHours(value)}` });
                   }}
                   style={{}}
                   placeholder="max"
@@ -274,7 +282,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
               <CustomInput
                 value={tags.perWeek.split("-")[0]}
                 handleChange={(value: string) => {
-                  setTags({ ...tags, perWeek: `${value}-${tags.perWeek.split("-")[1]}` });
+                  setTags({ ...tags, perWeek: `${roundOffHours(value)}-${tags.perWeek.split("-")[1]}` });
                 }}
                 style={{}}
                 placeholder="min"
@@ -284,7 +292,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
                 <CustomInput
                   value={tags.perWeek.split("-")[1]}
                   handleChange={(value: string) => {
-                    setTags({ ...tags, perWeek: `${tags.perWeek.split("-")[0]}-${value}` });
+                    setTags({ ...tags, perWeek: `${tags.perWeek.split("-")[0]}-${roundOffHours(value)}` });
                   }}
                   style={{}}
                   placeholder="max"
@@ -307,8 +315,8 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
               start
                 ? moment(start).format("YYYY-MM-DD")
                 : goal?.createdAt
-                  ? moment(goal.createdAt).format("YYYY-MM-DD")
-                  : today
+                ? moment(goal.createdAt).format("YYYY-MM-DD")
+                : today
             }
             timeValue={startTime}
           />

--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -264,8 +264,6 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
                 <CustomInput
                   value={tags.perDay.split("-")[1]}
                   handleChange={(value: string) => {
-                    console.log(`${tags.perDay.split("-")[0]}-${value}`);
-
                     setTags({ ...tags, perDay: `${tags.perDay.split("-")[0]}-${roundOffHours(value)}` });
                   }}
                   style={{}}


### PR DESCRIPTION
Resolves #1360 

Hi @Tushar-4781 & @tijlleenders 
This issue has been fixed. 

If input in decimal, it will be rounded off to the nearest whole number, with minimum value 1.

@tijlleenders, for the case of "0,5",where you mentioned that Dutch people use **comma** instead of **period**, this condition is already been handled, since the input type is set as **number**, it wont allow them to insert comma, while entering in hours.