### PR TITLE
add ADRs to documentation

### DIFF
--- a/documentation/ADR/000-template.md
+++ b/documentation/ADR/000-template.md
@@ -1,0 +1,20 @@
+# Title
+Template
+# Status
+Accepted (Proposed/ Accepted / Deprecated / Superseded by x / ...)
+# Context
+We needed a structured template to write down Architectural Decision Records (ADRs) in a uniform way
+# Decision
+Template ADR 000-template was added
+# Consequences
+There now is an ADR folder where decisions are registered
+# Alternatives considered
+/
+
+# Metadata
+#### Relevant issues/links
+/
+#### Proposed on
+2023-09-16
+#### Accepted on
+2023-09-16

--- a/documentation/technical/Readme.md
+++ b/documentation/technical/Readme.md
@@ -19,3 +19,8 @@ CI/CD : GithubActions and Vercel
 Internationalization : i18next  
 Progressive Web App : workbox  
 Animations : just CSS  
+
+## Architectural decisions  
+
+If an important architectural decision is made, it is best practice to document it as an ADR (Architectural Decision Record).
+This way there is always a reference of what architectural decisions are already made. You can find them in [the ADR folder](../ADR).


### PR DESCRIPTION
Kobe suggested we do this for the ZinZen-scheduler, and I think it's a good idea for this repo too.  
From my work experience this helps get new people up-to-speed on the core design decisions, and also helps avoid having the same discussion twice.