### PR TITLE
Fix for #1553 Url in parenthesis

### DIFF
--- a/src/components/GoalsComponents/GoalsList.tsx
+++ b/src/components/GoalsComponents/GoalsList.tsx
@@ -48,25 +48,21 @@ const GoalsList: React.FC<GoalsListProps> = ({ goals, showActions, setGoals, set
     const posIndexPromises = goals.map(async (ele, index) => updatePositionIndex(ele.id, index));
     Promise.all(posIndexPromises).catch((err) => console.log("error in sorting", err));
   };
-  return (
-    <>
-      {goals.map((goal: GoalItem, index: number) => (
-        <React.Fragment key={goal.id}>
-          {showUpdateGoal?.goalId === goal.id && <ConfigGoal action="Update" goal={goal} />}
-          <DragAndDrop
-            thisItem={goal.id === draggedItem?.id}
-            index={index}
-            dragging={dragging}
-            handleDragStart={handleDragStart}
-            handleDragEnter={handleDragEnter}
-            handleDragEnd={handleDragEnd}
-          >
-            <MyGoal goal={goal} showActions={showActions} setShowActions={setShowActions} />
-          </DragAndDrop>
-        </React.Fragment>
-      ))}
-    </>
-  );
+  return goals.map((goal: GoalItem, index: number) => (
+    <React.Fragment key={goal.id}>
+      {showUpdateGoal?.goalId === goal.id && <ConfigGoal action="Update" goal={goal} />}
+      <DragAndDrop
+        thisItem={goal.id === draggedItem?.id}
+        index={index}
+        dragging={dragging}
+        handleDragStart={handleDragStart}
+        handleDragEnter={handleDragEnter}
+        handleDragEnd={handleDragEnd}
+      >
+        <MyGoal goal={goal} showActions={showActions} setShowActions={setShowActions} />
+      </DragAndDrop>
+    </React.Fragment>
+  ));
 };
 
 export default GoalsList;

--- a/src/components/GoalsComponents/GoalsList.tsx
+++ b/src/components/GoalsComponents/GoalsList.tsx
@@ -51,7 +51,7 @@ const GoalsList: React.FC<GoalsListProps> = ({ goals, showActions, setGoals, set
   return (
     <>
       {goals.map((goal: GoalItem, index: number) => (
-        <>
+        <React.Fragment key={goal.id}>
           {showUpdateGoal?.goalId === goal.id && <ConfigGoal action="Update" goal={goal} />}
           <DragAndDrop
             thisItem={goal.id === draggedItem?.id}
@@ -63,7 +63,7 @@ const GoalsList: React.FC<GoalsListProps> = ({ goals, showActions, setGoals, set
           >
             <MyGoal goal={goal} showActions={showActions} setShowActions={setShowActions} />
           </DragAndDrop>
-        </>
+        </React.Fragment>
       ))}
     </>
   );

--- a/src/components/GoalsComponents/MyGoal.tsx
+++ b/src/components/GoalsComponents/MyGoal.tsx
@@ -207,22 +207,27 @@ const MyGoal: React.FC<MyGoalProps> = ({ goal, showActions, setShowActions }) =>
         <div aria-hidden className="goal-tile" onClick={handleGoalClick}>
           <div className="goal-title">
             {replacedString.split(" ").map((ele, index) => {
-              if (ele.includes("zURL-")) {
-                const urlIndex = Number(ele.split("-")[1]);
-                const originalUrl = urlsWithIndexes[urlIndex];
-                const summarizedUrl = summarizeUrl(originalUrl);
-                console.log(originalUrl);
-
+              const replacedUrls = Array.from(ele.matchAll(/zURL-(\d+)/g));
+              if (replacedUrls.length) {
                 return (
-                  <span
-                    key={`${goal.id}-${ele}`}
-                    style={{ cursor: "pointer", textDecoration: "underline" }}
-                    onClickCapture={() => {
-                      window.open(originalUrl, "_blank");
-                    }}
-                  >
-                    {index === 0 ? summarizedUrl : ` ${summarizedUrl}`}
-                  </span>
+                  <React.Fragment key={`${goal.id}-${ele}-replacedUrlsFragment`}>
+                    {replacedUrls.map(([url, digitStr]) => {
+                      const urlIndex = Number.parseInt(digitStr, 10);
+                      const originalUrl = urlsWithIndexes[urlIndex];
+                      const summarizedUrl = summarizeUrl(originalUrl);
+                      return (
+                        <span
+                          key={`${goal.id}-${ele}-${url}`}
+                          style={{ cursor: "pointer", textDecoration: "underline" }}
+                          onClickCapture={() => {
+                            window.open(originalUrl, "_blank");
+                          }}
+                        >
+                          {index === 0 ? summarizedUrl : ` ${summarizedUrl}`}
+                        </span>
+                      );
+                    })}
+                  </React.Fragment>
                 );
               }
               return <span key={`${goal.id}-${ele}`}>{index === 0 ? ele : ` ${ele}`}</span>;


### PR DESCRIPTION
Fixes issue #1553

The problem was with parsing URLs:
The following code
```
Number(ele.split("-")[1]);
```
returned NaN if there was anything other than digits after "-".
```
Number('zURL-5)'.split("-")[1]); // NaN since "5)" is not a number.
```

I used `String.matchAll` to get all URLs in the string (including edge cases like `(zURL-1)(zURL-2)`) and replace each one with a span.

Also added keys for react fragments in `GoalsList.tsx`: since they spammed in the console a lot :)