### PR TITLE
update docs to include command to access localhost on mobile devices

### DIFF
--- a/documentation/technical/Readme.md
+++ b/documentation/technical/Readme.md
@@ -11,6 +11,12 @@ npm install
 npm run dev
 ```
 
+To run the development server with hosting accessible on a mobile device, use:
+
+```
+npm run dev -- --host
+```
+
 ## Frameworks used
 
 UI : ~~react-bootstrap~~ antd  


### PR DESCRIPTION
This PR updates the technical docs to include instructions for running the development server with the `npm run dev -- --host` command. This allows users to access the local server on mobile devices.
