### PR TITLE
add branching convention to tech docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,16 @@
+# Branching convention
+
+[developer shortcut]/[issue number]/[meaningful name]
+
+like: alice/411/fix-budgets-on-weekends
+
+The branches should only be developed by the distinct developer and not mixed up.
+This helps retrace the development train of each developer and does not get confusing.
+
+Finished branches should be merged into the main branch after reviewing the pull request and then deleted.
+
+If someone likes work on a branch of another developer, then branch from this one with the above naming convention.
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/documentation/technical/Readme.md
+++ b/documentation/technical/Readme.md
@@ -30,3 +30,7 @@ Animations : just CSS
 
 If an important architectural decision is made, it is best practice to document it as an ADR (Architectural Decision Record).
 This way there is always a reference of what architectural decisions are already made. You can find them in [the ADR folder](../ADR).
+
+## Contributing
+
+We welcome contributions! Please respect our [contributing conventions](../../CONTRIBUTING.md).


### PR DESCRIPTION
Added a branching convention to the tech docs.  
This will help us navigate branches, stay out of each others way, and keep stale branches from becoming a thing. 