### PR TITLE
Change dark-mode input text to white

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -60,6 +60,7 @@ h6 {
 .popupModal-dark {
   p,
   button,
+  input,
   span,
   div,
   h1,


### PR DESCRIPTION
Fixes #1659 - Font color is now white for input fields in dark mode.