### PR TITLE
Feature: mechanism for goals to be shared after invite get accepted 

### DIFF
--- a/src/api/ContactsAPI/index.ts
+++ b/src/api/ContactsAPI/index.ts
@@ -109,3 +109,16 @@ export const addToSharingQueue = async (relId: string, goalId: string) => {
     console.log(e.stack || e);
   });
 };
+
+export const clearTheQueue = async (relId: string) => {
+  db.transaction("rw", db.contactsCollection, async () => {
+    await db.contactsCollection
+      .where("relId")
+      .equals(relId)
+      .modify((obj) => {
+        obj.goalsToBeShared = [];
+      });
+  }).catch((e) => {
+    console.log(e.stack || e);
+  });
+};

--- a/src/api/ContactsAPI/index.ts
+++ b/src/api/ContactsAPI/index.ts
@@ -22,6 +22,7 @@ export const addContact = async (contactName: string, relId: string, accepted = 
     relId,
     createdAt: currentDate,
     accepted,
+    goalsToBeShared: [],
   };
   let newContactId;
   await db

--- a/src/components/GoalsComponents/ShareGoalModal/ShareGoalModal.tsx
+++ b/src/components/GoalsComponents/ShareGoalModal/ShareGoalModal.tsx
@@ -72,7 +72,7 @@ const ShareGoalModal = ({ goal }: { goal: GoalItem }) => {
               setShowToast({
                 open: true,
                 message: "Link copied to clipboard",
-                extra: `Your invite hasn't been accepted yet. Send this link to ${name} so that they can add you in their contacts`,
+                extra: `Once your partner accepts the invitation link - your goals will be shared automatically`,
               });
             }
           }

--- a/src/components/GoalsComponents/ShareGoalModal/ShareGoalModal.tsx
+++ b/src/components/GoalsComponents/ShareGoalModal/ShareGoalModal.tsx
@@ -14,7 +14,7 @@ import { confirmAction } from "@src/Interfaces/IPopupModals";
 import { shareGoalWithContact } from "@src/services/contact.service";
 import { displayAddContact, displayShareModal } from "@src/store/GoalsState";
 import { darkModeState, displayToast, displayConfirmation } from "@src/store";
-import { checkAndUpdateRelationshipStatus, getAllContacts } from "@src/api/ContactsAPI";
+import { addToSharingQueue, checkAndUpdateRelationshipStatus, getAllContacts } from "@src/api/ContactsAPI";
 import { getGoal, getAllLevelGoalsOfId, shareMyGoalAnonymously, updateSharedStatusOfGoal } from "@src/api/GoalsAPI";
 
 import AddContactModal from "./AddContactModal";
@@ -65,6 +65,9 @@ const ShareGoalModal = ({ goal }: { goal: GoalItem }) => {
               setShowToast({ open: true, message: `Cheers!!, Your goal is shared with ${name}`, extra: "" });
               updateSharedStatusOfGoal(goal.id, relId, name).then(() => console.log("status updated"));
             } else {
+              await addToSharingQueue(relId, goal.id).catch(() => {
+                console.log("Unable to add this goal in queue");
+              });
               navigator.clipboard.writeText(`${window.location.origin}/invite/${relId}`);
               setShowToast({
                 open: true,

--- a/src/hooks/useApp.tsx
+++ b/src/hooks/useApp.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { lastAction, displayConfirmation, openDevMode, languageSelectionState, displayToast } from "@src/store";
 import { getTheme } from "@src/store/ThemeState";
 import { GoalItem } from "@src/models/GoalItem";
-import { checkMagicGoal, getAllLevelGoalsOfId, getGoal } from "@src/api/GoalsAPI";
+import { checkMagicGoal, getAllLevelGoalsOfId, getGoal, updateSharedStatusOfGoal } from "@src/api/GoalsAPI";
 import { addSharedWMGoal } from "@src/api/SharedWMAPI";
 import { createDefaultGoals } from "@src/helpers/NewUserController";
 import { refreshTaskCollection } from "@src/api/TasksAPI";
@@ -39,8 +39,7 @@ function useApp() {
         });
         await Promise.allSettled(
           contacts.map(async (contact) => {
-            const { goalsToBeShared, relId } = contact;
-
+            const { goalsToBeShared, relId, name } = contact;
             return Promise.allSettled([
               ...goalsToBeShared.map(async (goalId) => {
                 const goal = getGoal(goalId);
@@ -55,7 +54,9 @@ function useApp() {
                     parentGoalId: ele.id === goalId ? "root" : ele.parentGoalId,
                     rootGoalId: goalId,
                   })),
-                ]);
+                ]).then(async () => {
+                  updateSharedStatusOfGoal(goalId, relId, name).then(() => console.log("status updated"));
+                });
               }),
               clearTheQueue(relId),
             ]);

--- a/src/models/ContactItem.ts
+++ b/src/models/ContactItem.ts
@@ -3,5 +3,6 @@ export default interface ContactItem {
   name: string;
   relId: string;
   accepted: boolean;
+  goalsToBeShared: string[];
   createdAt: Date;
 }

--- a/src/models/db.ts
+++ b/src/models/db.ts
@@ -8,7 +8,7 @@ import { TaskItem } from "./TaskItem";
 import { GCustomItem } from "./GCustomItem";
 import { DumpboxItem } from "./DumpboxItem";
 
-export const dexieVersion = 16;
+export const dexieVersion = 17;
 
 const currentVersion = Number(localStorage.getItem("dexieVersion") || dexieVersion);
 localStorage.setItem("dexieVersion", `${dexieVersion}`);
@@ -39,7 +39,7 @@ export class ZinZenDB extends Dexie {
           "id, title, duration, sublist, habit, on, start, due, afterTime, beforeTime, createdAt, parentGoalId, archived, participants, goalColor, language, link, rootGoalId, timeBudget, typeOfGoal",
         sharedWMCollection:
           "id, title, duration, sublist, repeat, start, due, afterTime, beforeTime, createdAt, parentGoalId, participants, archived, goalColor, language, link, rootGoalId, timeBudget, typeOfGoal",
-        contactsCollection: "id, name, relId, accepted, createdAt",
+        contactsCollection: "id, name, relId, accepted, goalsToBeShared, createdAt",
         outboxCollection: null,
         inboxCollection: "id, goalChanges",
         pubSubCollection: "id, subscribers",
@@ -117,6 +117,12 @@ export class ZinZenDB extends Dexie {
           });
           goalsCollection.toCollection().modify((goal: GoalItem) => {
             goal.newUpdates = false;
+          });
+        }
+        if (currentVersion < 17) {
+          const contactsCollection = trans.table("contactsCollection");
+          contactsCollection.toCollection().modify((contact) => {
+            contact.goalsToBeShared = [];
           });
         }
       });


### PR DESCRIPTION
Resolves #1709  
PR Doc: 
1. Upon adding a contact, the goal ID will be saved in the "goalsToBeShared" field within the contacts collection.
2. Once a confirmation message is received indicating the acceptance of the invitation by the second person, a trigger will be activated.
3. The trigger will facilitate the sharing of all goals stored in the "goalsToBeShared" field.