### PR TITLE
refactor: introducing generic Custom ZModal for reduced redundancy and enhanced maintainability

### DIFF
--- a/src/Interfaces/ICommon.ts
+++ b/src/Interfaces/ICommon.ts
@@ -25,6 +25,7 @@ export interface ZModalProps {
   open: boolean;
   onCancel: () => void;
   width?: number;
+  style?: React.CSSProperties;
 }
 
 export interface ColorPaletteProps {

--- a/src/Interfaces/ICommon.ts
+++ b/src/Interfaces/ICommon.ts
@@ -18,6 +18,15 @@ export interface ZAccordionProps {
   defaultActiveKey?: string[];
   onChange?: (key: string | string[]) => void;
 }
+
+export interface ZModalProps {
+  children: React.ReactNode;
+  type?: string;
+  open: boolean;
+  onCancel: () => void;
+  width?: number;
+}
+
 export interface ColorPaletteProps {
   colorIndex: number;
   setColorIndex: SetterOrUpdater<number>;

--- a/src/common/ConfirmationModal.tsx
+++ b/src/common/ConfirmationModal.tsx
@@ -1,16 +1,15 @@
-import { Checkbox, Modal } from "antd";
+import { Checkbox } from "antd";
 import React, { useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { useTranslation } from "react-i18next";
 
-import { themeState } from "@src/store/ThemeState";
 import { darkModeState, displayConfirmation } from "@src/store";
 import { getConfirmButtonText } from "@src/constants/myGoals";
 import { ConfirmationModalProps } from "@src/Interfaces/IPopupModals";
+import ZModal from "./ZModal";
 
 const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ action, handleClick }) => {
   const { t } = useTranslation();
-  const theme = useRecoilValue(themeState);
   const darkModeStatus = useRecoilValue(darkModeState);
 
   const { actionCategory, actionName } = action;
@@ -48,19 +47,10 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ action, handleCli
     </button>
   );
   return (
-    <Modal
+    <ZModal
       open={displayModal.open}
-      closable={false}
-      footer={null}
-      centered
       onCancel={() => {
         window.history.back();
-      }}
-      className={`popupModal${darkModeStatus ? "-dark" : ""} ${darkModeStatus ? "dark" : "light"}-theme${
-        theme[darkModeStatus ? "dark" : "light"]
-      }`}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
       }}
     >
       <p className="popupModal-title" style={{ margin: 0 }}>
@@ -84,7 +74,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ action, handleCli
         {getChoiceButton("cancel")}
         {getChoiceButton(getConfirmButtonText(actionName))}
       </div>
-    </Modal>
+    </ZModal>
   );
 };
 

--- a/src/common/ZModal.tsx
+++ b/src/common/ZModal.tsx
@@ -5,7 +5,7 @@ import { darkModeState } from "@src/store";
 import { themeState } from "@src/store/ThemeState";
 import { ZModalProps } from "@src/Interfaces/ICommon";
 
-const ZModal: React.FC<ZModalProps> = ({ children, type, open, onCancel, width }) => {
+const ZModal: React.FC<ZModalProps> = ({ children, type, open, onCancel, width, style }) => {
   const theme = useRecoilValue(themeState);
   const darkModeStatus = useRecoilValue(darkModeState);
 
@@ -28,6 +28,7 @@ const ZModal: React.FC<ZModalProps> = ({ children, type, open, onCancel, width }
       className={combinedClassName}
       maskStyle={maskStyle}
       width={width}
+      style={style}
     >
       {children}
     </Modal>

--- a/src/common/ZModal.tsx
+++ b/src/common/ZModal.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Modal } from "antd";
+import { useRecoilValue } from "recoil";
+import { darkModeState } from "@src/store";
+import { themeState } from "@src/store/ThemeState";
+
+interface ZModalProps {
+  children: React.ReactNode;
+  className: string;
+  open: boolean;
+  onCancel: () => void;
+  width: number;
+}
+
+const ZModal: React.FC<ZModalProps> = ({ children, className, open, onCancel, width }) => {
+  const theme = useRecoilValue(themeState);
+  const darkModeStatus = useRecoilValue(darkModeState);
+
+  const commonClassName = `popupModal${darkModeStatus ? "-dark" : ""} ${darkModeStatus ? "dark" : "light"}-theme${
+    theme[darkModeStatus ? "dark" : "light"]
+  }`;
+  const combinedClassName = `${className} ${commonClassName}`;
+
+  const maskStyle = {
+    backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
+  };
+
+  return (
+    <Modal
+      open={open}
+      closable={false}
+      footer={null}
+      centered
+      onCancel={onCancel || (() => window.history.back())}
+      className={combinedClassName}
+      maskStyle={maskStyle}
+      width={width}
+    >
+      {children}
+    </Modal>
+  );
+};
+
+export default ZModal;

--- a/src/common/ZModal.tsx
+++ b/src/common/ZModal.tsx
@@ -3,23 +3,16 @@ import { Modal } from "antd";
 import { useRecoilValue } from "recoil";
 import { darkModeState } from "@src/store";
 import { themeState } from "@src/store/ThemeState";
+import { ZModalProps } from "@src/Interfaces/ICommon";
 
-interface ZModalProps {
-  children: React.ReactNode;
-  className: string;
-  open: boolean;
-  onCancel: () => void;
-  width: number;
-}
-
-const ZModal: React.FC<ZModalProps> = ({ children, className, open, onCancel, width }) => {
+const ZModal: React.FC<ZModalProps> = ({ children, type, open, onCancel, width }) => {
   const theme = useRecoilValue(themeState);
   const darkModeStatus = useRecoilValue(darkModeState);
 
   const commonClassName = `popupModal${darkModeStatus ? "-dark" : ""} ${darkModeStatus ? "dark" : "light"}-theme${
     theme[darkModeStatus ? "dark" : "light"]
   }`;
-  const combinedClassName = `${className} ${commonClassName}`;
+  const combinedClassName = `${type} ${commonClassName}`;
 
   const maskStyle = {
     backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",

--- a/src/components/BackupRestoreModal.tsx
+++ b/src/components/BackupRestoreModal.tsx
@@ -1,15 +1,14 @@
 import React from "react";
-import { Modal } from "antd";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
 import { db } from "@models";
-import { themeState } from "@src/store/ThemeState";
 import { backupRestoreModal, darkModeState, displayToast, lastAction } from "@src/store";
 
 import "dexie-export-import";
 import "./index.scss";
 import { GoalItem } from "@src/models/GoalItem";
 import { TaskItem } from "@src/models/TaskItem";
+import ZModal from "@src/common/ZModal";
 
 const backupImg =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAAsTAAALEwEAmpwYAAADB0lEQVR4nO2Z3YtMYRzHP3a9jpc21sxQ5C1FFFHakJeibd24EQnXe4H2brkTpVUU+QMWiVLWhfdEsSHvNizLtkoJid3FLlvs6Nm+R481M7szc87OeTSfOs0855zn9/y+53n7nd+BAgUKhIHBwAJgE7Ad2AqsBRYCxTjAIuAI8BVIpDg+ArVAGSFkAnAK6LYcfg6cAA4Bh4E64FkvUXXAdELCcuC9HPsM7AYmpbl/BrALaFedVqCcPLMa+C6HTgLRDOqOV4+Zuj+BLeSJ2cA3ObIzSxuDVNcMyS5gCQER0UqzUkPCYwjwVCL2+NDOXtkyQ7QEH5kGHAc6e03ORmAdUKXydaDIh/aKgKuyWYNPlFsT0YzdR8A14LUlyAyFX8AsvxoF5smmeXgxP4x1yNlaLas2ZRLmLZ1+c0a2K3M1dFOG9vUxbyr9eGpJ2Kz2L5ID82XklSZzPojKh0+5GKnycRXKhU75MSKbykuB+zKQt41JtMiPqWRAzJpgXkBn7xf54K18OQCsAYb2VWGmtaS2aKJl1Z0+86TX3vUBqE41b8cBzbrxNDCK8DAGWAxs1KbcJT/vJovljuni5TyuUP3FRBm3rcjCCP0T7HVr956IGwxXOJRQL/WwXycO4hZx4Is6wUQgPJCQZbhHjd0JrSqMDagxMwTuBZgTSGhl44cKwwJqzFs2g6BEtttM4Y0K6d6rwypkpGybN1OuqLDeQSFzZPulKWxT4ayDQqqtdyVKrTdAk8pxRUjEisMqvJM7dOIdMMURIUdl95ayLz2Y/OsFS8yKEAuJWCLaFZn8xWjgvNXwOWADMLk/oXPAQiLAXM0JbziZXX1VqgrFurktTdI51VGfhZD6LNpJaDj90xPJKFXq/5L2GS90TnfcCFBIB9Ck1anCnhMDSZDL74BSEBI2nOyRh8BjvfSkEmKuNQB3CDEN1me2eBIhcV1LKGccWqLWd5Im5QA8ITHr2gsX8gNx66l7v/Z/u7dCT9R6+vbhRE/0JcZJER5xJdEaXRpO6Xomk8/UBfgf+A3SSyxFIXLo1QAAAABJRU5ErkJggg==";
@@ -17,7 +16,6 @@ const restoreImg =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAAsTAAALEwEAmpwYAAADnUlEQVR4nO2ay05UQRCGPyMMkyg3AVHcyE6jQZ5CQUVBV6hbI1FE5AHEpUFXRl4EMYTERBFBkIuSqAjISmWhxAUaLkIc08l/kg7OMJc+5zBj+JMOM3Sfrq5T1d1Vfw3s4P9FEXARuAf0AjPAN2AVWAN+ANPAE+A+cB4oDXpRo8CrFMblA83AU+A3EEuzbQD9wBWgIAhFPEGJEAE6gAVr7DrwDOiUZY4AFVpgvt7+UaARuKOxq9bzXzVnNCxFzgBz1pgp4GqGblKiZ8et+T4B9QSoiHlTj4A/6nvnp0CgDnhjye72wzqbFdkPjOl/xh1uA3n4j93ALWBZsozMSr8UOQzM6rtxqVqCR41OPU9mtasi5daE47JMWCgFXkr2PHDARZER/X0NFBI+9lhrGMtkz9hn/byrnzqizPIKcwCkhVQvtEHCQY11AJjTzXdFXhAe2q3N7+ulGTbygLdSxiiV0zgtRRZy3Sq7gAkpc4kcxzUp0keOo1T5jYm2i4MWZkL3m7rMfqmZ/KZVKYArnssq5wgQh6zTJV6bBKocZdzVXF0EaAlPifdKZwvVGpXqxrRhXSzTpHkeExDaJOBDAv8ttpS54SDnmOb4SIC5fkyWSPY2U+EEEqFcc3yP1znoQ+z0UwIKk7AtZsySowvHlOT9gzV1uvjuUgqKFAetyKI6TdicKbzcwWzsRLigMcNBudasOg1lkylaNcd0gs1eYuUW14Pa7L0pbNRkiOie8IQ0aU8UyRJ22my4rkzRpHl64nU+UKchz1xQZSkTrxklDgZ5ITaq0zCArojonhjWSWbakNzJxRIeBrTWBhIEYxs6CYwvZyv2WUGjcdm46JemhsbMVrRojYbVT4jLlh9na2I1qTWaKsCWF80XDTxF9uGs1vY5lTJEhxVuGy42m8iHKa3NBKdJERW1HxOhnC3o0Jpm0ikK1euhZZFj241aYEVrOpnuw93WG3CJv1xRYRWWHmYyQdSqiYyIUA4be60cZ9SlzlihmMlj5M33MC++Iasc50ykV1umNW52gnD2xJxkzqrY5AsqLTdbFvcaROktT6fTiuVOvheXotYBEBNbUu/jjW2qxd494W3sQGrvHuo2lacnRGOWZrgPWjaF/bOZHLEu1mm3wpmYItIB/WCgSVlcmUL6iD4fV4LVqbEeT+CFHW1BWyERCsSK9ykFiKXZ1hXFNm+XAvFQrESnSwzgtAiNNbVFEXc9GtOwVT6xA3IcfwEzCVxsbkJcggAAAABJRU5ErkJggg==";
 
 const BackupRestoreModal = () => {
-  const theme = useRecoilValue(themeState);
   const open = useRecoilValue(backupRestoreModal);
   const darkModeStatus = useRecoilValue(darkModeState);
   const setShowToast = useSetRecoilState(displayToast);
@@ -164,19 +162,7 @@ const BackupRestoreModal = () => {
     </button>
   );
   return (
-    <Modal
-      open={open}
-      closable={false}
-      footer={null}
-      centered
-      onCancel={() => window.history.back()}
-      className={`backupRestoreModal popupModal${darkModeStatus ? "-dark" : ""} ${
-        darkModeStatus ? "dark" : "light"
-      }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
-    >
+    <ZModal open={open} onCancel={() => window.history.back()} type="backupRestoreModal">
       <p className="popupModal-title" style={{ textAlign: "center" }}>
         {" "}
         Choose an option from below
@@ -186,7 +172,7 @@ const BackupRestoreModal = () => {
         {getOption("Restore")}
       </div>
       <input type="file" id="backupFileInput" style={{ display: "none" }} onChange={restoreData} />
-    </Modal>
+    </ZModal>
   );
 };
 

--- a/src/components/FeelingsComponents/AddFeeling.tsx
+++ b/src/components/FeelingsComponents/AddFeeling.tsx
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import React, { useState } from "react";
-import { Modal } from "antd";
 import { useTranslation } from "react-i18next";
 import { useRecoilValue } from "recoil";
 
@@ -14,6 +13,7 @@ import { feelingsList, feelingsCategories, feelingsEmojis } from "@consts/Feelin
 
 import "@translations/i18n";
 import "./AddFeeling.scss";
+import ZModal from "@src/common/ZModal";
 
 export const AddFeeling = ({ feelingDate }: { feelingDate: Date | null }) => {
   const { t } = useTranslation();
@@ -46,19 +46,10 @@ export const AddFeeling = ({ feelingDate }: { feelingDate: Date | null }) => {
     window.history.back();
   };
   return (
-    <Modal
-      footer={null}
-      closable={false}
+    <ZModal
+      type={`notes-modal${darkModeStatus ? "-dark" : ""}`}
       open={!!feelingDate}
-      className={`notes-modal${darkModeStatus ? "-dark" : ""} popupModal${darkModeStatus ? "-dark" : ""} ${
-        darkModeStatus ? "dark" : "light"
-      }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-      onCancel={() => {
-        window.history.back();
-      }}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
+      onCancel={() => window.history.back()}
     >
       {selectedCategory === "" ? (
         <>
@@ -141,6 +132,6 @@ export const AddFeeling = ({ feelingDate }: { feelingDate: Date | null }) => {
           </button>
         </div>
       )}
-    </Modal>
+    </ZModal>
   );
 };

--- a/src/components/GoalsComponents/DisplayChangesModal/DisplayChangesModal.tsx
+++ b/src/components/GoalsComponents/DisplayChangesModal/DisplayChangesModal.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable consistent-return */
-import { Checkbox, Modal } from "antd";
+import { Checkbox } from "antd";
 import React, { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 
 import { GoalItem } from "@src/models/GoalItem";
-import { themeState } from "@src/store/ThemeState";
 import { ITagsChanges } from "@src/Interfaces/IDisplayChangesModal";
 import { sendNewGoals } from "@src/helpers/BatchPublisher";
 import { darkModeState } from "@src/store";
@@ -18,6 +17,7 @@ import { findGoalTagChanges, jumpToLowestChanges } from "@src/helpers/GoalProces
 import { acceptSelectedSubgoals, acceptSelectedTags } from "@src/helpers/InboxProcessor";
 import SubHeader from "@src/common/SubHeader";
 import ContactItem from "@src/models/ContactItem";
+import ZModal from "@src/common/ZModal";
 
 import Header from "./Header";
 import AcceptBtn from "./AcceptBtn";
@@ -25,7 +25,6 @@ import IgnoreBtn from "./IgnoreBtn";
 import "./DisplayChangesModal.scss";
 
 const DisplayChangesModal = () => {
-  const theme = useRecoilValue(themeState);
   const darkModeStatus = useRecoilValue(darkModeState);
   const showChangesModal = useRecoilValue(displayChangesModal);
 
@@ -221,20 +220,7 @@ const DisplayChangesModal = () => {
     init();
   }, []);
   return (
-    <Modal
-      className={`popupModal${darkModeStatus ? "-dark" : ""} ${darkModeStatus ? "dark" : "light"}-theme${
-        theme[darkModeStatus ? "dark" : "light"]
-      }`}
-      open={!!showChangesModal}
-      onCancel={() => {
-        window.history.back();
-      }}
-      closable={false}
-      footer={null}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
-    >
+    <ZModal type="popupModal" open={!!showChangesModal} onCancel={() => window.history.back()}>
       {showChangesModal && (
         <>
           <SubHeader
@@ -300,7 +286,7 @@ const DisplayChangesModal = () => {
           </div>
         </>
       )}
-    </Modal>
+    </ZModal>
   );
 };
 

--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -23,6 +23,7 @@ import { colorPalleteList, calDays, convertOnFilterToArray } from "../../../util
 
 import "./ConfigGoal.scss";
 import CustomDatePicker from "./CustomDatePicker";
+import CustomModal from "@src/common/ZModal";
 
 const onDays = [...calDays.slice(1), "Sun"];
 
@@ -215,22 +216,16 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
   }, [afterTime, beforeTime, numberOfDays, betweenSliderUpdated]);
 
   return (
-    <Modal
-      className={`configModal popupModal${darkModeStatus ? "-dark" : ""} 
-        ${darkModeStatus ? "dark" : "light"}-theme${theme[darkModeStatus ? "dark" : "light"]}`}
+    <CustomModal
+      type="configModal"
       open={open}
       width={360}
-      closable={false}
-      footer={null}
       onCancel={async () => {
         if (title !== "") {
           await handleSave();
         } else {
           window.history.back();
         }
-      }}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
       }}
     >
       <div style={{ textAlign: "left" }} className="header-title">
@@ -420,7 +415,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
           </button>
         </div>
       </div>
-    </Modal>
+    </CustomModal>
   );
 };
 

--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -1,8 +1,7 @@
 import { SliderMarks } from "antd/es/slider";
 import { useTranslation } from "react-i18next";
 import React, { useEffect, useState } from "react";
-import { Modal, Slider, Switch } from "antd";
-import { darkModeState, displayToast, openDevMode } from "@src/store";
+import { Slider, Switch } from "antd";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocation } from "react-router-dom";
 
@@ -11,8 +10,8 @@ import plingSound from "@assets/pling.mp3";
 
 import ZAccordion from "@src/common/Accordion";
 import ColorPicker from "@src/common/ColorPicker";
+import CustomModal from "@src/common/ZModal";
 import { GoalItem } from "@src/models/GoalItem";
-import { themeState } from "@src/store/ThemeState";
 import { ILocationState } from "@src/Interfaces";
 import { getSharedWMGoal } from "@src/api/SharedWMAPI";
 import { ICustomInputProps } from "@src/Interfaces/IPopupModals";
@@ -23,7 +22,6 @@ import { colorPalleteList, calDays, convertOnFilterToArray } from "../../../util
 
 import "./ConfigGoal.scss";
 import CustomDatePicker from "./CustomDatePicker";
-import CustomModal from "@src/common/ZModal";
 
 const onDays = [...calDays.slice(1), "Sun"];
 
@@ -49,8 +47,6 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
   const { state }: { state: ILocationState } = useLocation();
   const mySound = new Audio(plingSound);
 
-  const theme = useRecoilValue(themeState);
-  const darkModeStatus = useRecoilValue(darkModeState);
   const subGoalsHistory = useRecoilValue(goalsHistory);
   const ancestors = subGoalsHistory.map((ele) => ele.goalID);
 

--- a/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/ConfigGoal.tsx
@@ -2,6 +2,7 @@ import { SliderMarks } from "antd/es/slider";
 import { useTranslation } from "react-i18next";
 import React, { useEffect, useState } from "react";
 import { Slider, Switch } from "antd";
+import { darkModeState, displayToast, openDevMode } from "@src/store";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocation } from "react-router-dom";
 
@@ -10,8 +11,8 @@ import plingSound from "@assets/pling.mp3";
 
 import ZAccordion from "@src/common/Accordion";
 import ColorPicker from "@src/common/ColorPicker";
-import CustomModal from "@src/common/ZModal";
 import { GoalItem } from "@src/models/GoalItem";
+import ZModal from "@src/common/ZModal";
 import { ILocationState } from "@src/Interfaces";
 import { getSharedWMGoal } from "@src/api/SharedWMAPI";
 import { ICustomInputProps } from "@src/Interfaces/IPopupModals";
@@ -47,6 +48,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
   const { state }: { state: ILocationState } = useLocation();
   const mySound = new Audio(plingSound);
 
+  const darkModeStatus = useRecoilValue(darkModeState);
   const subGoalsHistory = useRecoilValue(goalsHistory);
   const ancestors = subGoalsHistory.map((ele) => ele.goalID);
 
@@ -212,7 +214,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
   }, [afterTime, beforeTime, numberOfDays, betweenSliderUpdated]);
 
   return (
-    <CustomModal
+    <ZModal
       type="configModal"
       open={open}
       width={360}
@@ -411,7 +413,7 @@ const ConfigGoal = ({ goal, action }: { action: "Update" | "Create"; goal: GoalI
           </button>
         </div>
       </div>
-    </CustomModal>
+    </ZModal>
   );
 };
 

--- a/src/components/GoalsComponents/MyGoalActions/MyGoalActions.tsx
+++ b/src/components/GoalsComponents/MyGoalActions/MyGoalActions.tsx
@@ -9,7 +9,14 @@ import { unarchiveUserGoal } from "@src/api/GoalsAPI";
 import { unarchiveIcon } from "@src/assets";
 import ZModal from "@src/common/ZModal";
 
-import { displayToast, lastAction, openDevMode, displayConfirmation, displayPartnerMode } from "@src/store";
+import {
+  displayToast,
+  lastAction,
+  openDevMode,
+  displayConfirmation,
+  displayPartnerMode,
+  darkModeState,
+} from "@src/store";
 import { GoalItem } from "@src/models/GoalItem";
 import { goalsHistory } from "@src/store/GoalsState";
 import { confirmAction } from "@src/Interfaces/IPopupModals";
@@ -29,6 +36,7 @@ const MyGoalActions = ({ goal, open }: { open: boolean; goal: GoalItem }) => {
   const isPartnerGoal = useRecoilValue(displayPartnerMode);
   const setDevMode = useSetRecoilState(openDevMode);
   const setShowToast = useSetRecoilState(displayToast);
+  const darkModeStatus = useRecoilValue(darkModeState);
   const setLastAction = useSetRecoilState(lastAction);
   const ancestors = subGoalsHistory.map((ele) => ele.goalID);
 

--- a/src/components/GoalsComponents/MyGoalActions/MyGoalActions.tsx
+++ b/src/components/GoalsComponents/MyGoalActions/MyGoalActions.tsx
@@ -1,5 +1,4 @@
-import { Modal, Tooltip } from "antd";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -8,17 +7,10 @@ import useGoalStore from "@src/hooks/useGoalStore";
 import ConfirmationModal from "@src/common/ConfirmationModal";
 import { unarchiveUserGoal } from "@src/api/GoalsAPI";
 import { unarchiveIcon } from "@src/assets";
+import ZModal from "@src/common/ZModal";
 
-import {
-  darkModeState,
-  displayToast,
-  lastAction,
-  openDevMode,
-  displayConfirmation,
-  displayPartnerMode,
-} from "@src/store";
+import { displayToast, lastAction, openDevMode, displayConfirmation, displayPartnerMode } from "@src/store";
 import { GoalItem } from "@src/models/GoalItem";
-import { themeState } from "@src/store/ThemeState";
 import { goalsHistory } from "@src/store/GoalsState";
 import { confirmAction } from "@src/Interfaces/IPopupModals";
 import { convertSharedWMGoalToColab } from "@src/api/SharedWMAPI";
@@ -32,8 +24,6 @@ const MyGoalActions = ({ goal, open }: { open: boolean; goal: GoalItem }) => {
   const { handleUpdateGoal, handleShareGoal, handleConfirmation } = useGoalStore();
   const confirmActionCategory = goal.typeOfGoal === "shared" && goal.parentGoalId === "root" ? "collaboration" : "goal";
 
-  const theme = useRecoilValue(themeState);
-  const darkModeStatus = useRecoilValue(darkModeState);
   const subGoalsHistory = useRecoilValue(goalsHistory);
   const showConfirmation = useRecoilValue(displayConfirmation);
   const isPartnerGoal = useRecoilValue(displayPartnerMode);
@@ -82,20 +72,7 @@ const MyGoalActions = ({ goal, open }: { open: boolean; goal: GoalItem }) => {
   const isGoalArchived = goal.archived;
 
   return (
-    <Modal
-      open={open}
-      closable={false}
-      footer={null}
-      centered
-      width={400}
-      onCancel={() => window.history.back()}
-      className={`interactables-modal popupModal${darkModeStatus ? "-dark" : ""} ${
-        darkModeStatus ? "dark" : "light"
-      }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
-    >
+    <ZModal open={open} width={400} onCancel={() => window.history.back()} type="interactables-modal">
       <div
         style={{ textAlign: "left" }}
         className="header-title"
@@ -192,7 +169,7 @@ const MyGoalActions = ({ goal, open }: { open: boolean; goal: GoalItem }) => {
           </>
         )}
       </div>
-    </Modal>
+    </ZModal>
   );
 };
 

--- a/src/components/GoalsComponents/Participants.tsx
+++ b/src/components/GoalsComponents/Participants.tsx
@@ -1,17 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { useRecoilValue } from "recoil";
 import { followContactOnGoal, getGoal } from "@src/api/GoalsAPI";
 import { IParticipant } from "@src/models/GoalItem";
-import { darkModeState } from "@src/store";
-import { themeState } from "@src/store/ThemeState";
-import { Modal, Switch } from "antd";
+import { Switch } from "antd";
 import CrossIcon from "@assets/images/deleteIcon.svg";
 import TickIcon from "@assets/images/correct.svg";
+import ZModal from "@src/common/ZModal";
 
 const Participants = ({ goalId }: { goalId: string }) => {
-  const theme = useRecoilValue(themeState);
-  const darkModeStatus = useRecoilValue(darkModeState);
-
   const [list, setList] = useState<IParticipant[]>([]);
 
   const getParticipants = async () => {
@@ -34,21 +29,7 @@ const Participants = ({ goalId }: { goalId: string }) => {
   };
 
   return (
-    <Modal
-      className={`configModal popupModal${darkModeStatus ? "-dark" : ""} ${darkModeStatus ? "dark" : "light"}-theme${
-        theme[darkModeStatus ? "dark" : "light"]
-      }`}
-      open
-      width={360}
-      closable={false}
-      footer={null}
-      onCancel={() => {
-        window.history.back();
-      }}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
-    >
+    <ZModal type="configModal" open onCancel={() => window.history.back()}>
       <div style={{ textAlign: "left", padding: 20, fontSize: 16, fontWeight: 600 }} className="header-title">
         Following
       </div>
@@ -78,7 +59,7 @@ const Participants = ({ goalId }: { goalId: string }) => {
           </div>
         ))}
       </div>
-    </Modal>
+    </ZModal>
   );
 };
 

--- a/src/components/GoalsComponents/ShareGoalModal/AddContactModal.tsx
+++ b/src/components/GoalsComponents/ShareGoalModal/AddContactModal.tsx
@@ -4,11 +4,9 @@ import { shareInvitation } from "@src/assets";
 import Loader from "@src/common/Loader";
 import { initRelationship } from "@src/services/contact.service";
 import { darkModeState, displayToast } from "@src/store";
-import { themeState } from "@src/store/ThemeState";
 import React, { useState } from "react";
-import { Modal } from "antd";
 import { useRecoilValue, useSetRecoilState } from "recoil";
-import { createPartner } from "@src/api/PartnerAPI";
+import ZModal from "@src/common/ZModal";
 
 interface AddContactModalProps {
   showAddContactModal: boolean;
@@ -16,7 +14,6 @@ interface AddContactModalProps {
 }
 const AddContactModal: React.FC<AddContactModalProps> = ({ showAddContactModal, setShowAddContactModal }) => {
   const darkModeStatus = useRecoilValue(darkModeState);
-  const theme = useRecoilValue(themeState);
   const [loading, setLoading] = useState(false);
   const [newContact, setNewContact] = useState<{ contactName: string; relId: string } | null>(null);
   const handleCloseAddContact = () => {
@@ -61,20 +58,12 @@ const AddContactModal: React.FC<AddContactModalProps> = ({ showAddContactModal, 
     setLoading(false);
   };
   return (
-    <Modal
-      closable={false}
-      footer={null}
-      centered
+    <ZModal
+      type="addContact-modal"
       open={showAddContactModal}
       onCancel={() => {
         setNewContact(null);
         handleCloseAddContact();
-      }}
-      className={`addContact-modal popupModal${darkModeStatus ? "-dark" : ""} ${
-        darkModeStatus ? "dark" : "light"
-      }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
       }}
     >
       <p className="popupModal-title"> Add a contact name </p>
@@ -107,7 +96,7 @@ const AddContactModal: React.FC<AddContactModalProps> = ({ showAddContactModal, 
         {loading ? <Loader /> : <img alt="add contact" className="theme-icon" src={shareInvitation} />}
         <span style={loading ? { marginLeft: 28 } : {}}>Share invitation</span>
       </button>
-    </Modal>
+    </ZModal>
   );
 };
 

--- a/src/components/GoalsComponents/ShareGoalModal/ShareGoalModal.tsx
+++ b/src/components/GoalsComponents/ShareGoalModal/ShareGoalModal.tsx
@@ -1,4 +1,3 @@
-import { Modal } from "antd";
 import React, { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
@@ -8,8 +7,8 @@ import GlobalAddIcon from "@assets/images/globalAdd.svg";
 import Loader from "@src/common/Loader";
 import ContactItem from "@src/models/ContactItem";
 import ConfirmationModal from "@src/common/ConfirmationModal";
+import ZModal from "@src/common/ZModal";
 import { GoalItem } from "@src/models/GoalItem";
-import { themeState } from "@src/store/ThemeState";
 import { confirmAction } from "@src/Interfaces/IPopupModals";
 import { shareGoalWithContact } from "@src/services/contact.service";
 import { displayAddContact, displayShareModal } from "@src/store/GoalsState";
@@ -25,7 +24,6 @@ const ShareGoalModal = ({ goal }: { goal: GoalItem }) => {
   const minContacts = 10;
   const navigate = useNavigate();
   const { state } = useLocation();
-  const theme = useRecoilValue(themeState);
   const darkModeStatus = useRecoilValue(darkModeState);
   const showShareModal = useRecoilValue(displayShareModal);
 
@@ -123,19 +121,11 @@ const ShareGoalModal = ({ goal }: { goal: GoalItem }) => {
     })();
   }, [showAddContactModal]);
   return (
-    <Modal
+    <ZModal
       open={!!showShareModal}
-      closable={false}
-      footer={null}
-      centered
       style={showAddContactModal ? { zIndex: 1 } : {}}
       onCancel={() => window.history.back()}
-      className={`share-modal${darkModeStatus ? "-dark" : ""} popupModal${darkModeStatus ? "-dark" : ""} ${
-        darkModeStatus ? "dark" : "light"
-      }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
+      type={`share-modal${darkModeStatus ? "-dark" : ""}`}
     >
       {confirmationAction && <ConfirmationModal action={confirmationAction} handleClick={handleActionClick} />}
       <p className="popupModal-title">{displaySubmenu === "groups" ? "Share in Public Group" : "Share Goals"}</p>
@@ -206,7 +196,7 @@ const ShareGoalModal = ({ goal }: { goal: GoalItem }) => {
       {showAddContactModal && (
         <AddContactModal showAddContactModal={showAddContactModal} setShowAddContactModal={setShowAddContactModal} />
       )}
-    </Modal>
+    </ZModal>
   );
 };
 

--- a/src/components/LanguageChangeModal/LanguageChangeModal.tsx
+++ b/src/components/LanguageChangeModal/LanguageChangeModal.tsx
@@ -2,22 +2,18 @@
 import React, { useLayoutEffect, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 
-import { Modal } from "antd";
-
 import { ILanguage } from "@src/Interfaces";
 import { i18n } from "@src/translations/i18n";
 
-import { themeState } from "@src/store/ThemeState";
-import { languageChangeModal, languageSelectionState, darkModeState } from "@src/store";
+import { languageChangeModal, languageSelectionState } from "@src/store";
 import "./index.scss";
 import { LanguagesList } from "@components/LanguageChoice/LanguagesList";
 import { getLanguages } from "@src/constants/languages";
+import ZModal from "@src/common/ZModal";
 
 export const LanguageChangeModal = () => {
   const [, setPosition] = useState(1);
   const open = useRecoilValue(languageChangeModal);
-  const darkModeStatus = useRecoilValue(darkModeState);
-  const theme = useRecoilValue(themeState);
   const [IsLanguageChosen] = useRecoilState(languageSelectionState);
   const langSelected = (lang: string, newPos: number) => {
     if (i18n.language.includes(lang)) {
@@ -44,21 +40,8 @@ export const LanguageChangeModal = () => {
   }, [IsLanguageChosen]);
 
   return (
-    <Modal
-      open={!!open}
-      closable={false}
-      footer={null}
-      centered
-      onCancel={() => window.history.back()}
-      width={200}
-      className={`languageChangeModal popupModal${darkModeStatus ? "-dark" : ""} ${
-        darkModeStatus ? "dark" : "light"
-      }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
-    >
+    <ZModal type="languageChangeModal" open={!!open} onCancel={() => window.history.back()} width={200}>
       <LanguagesList languages={Languages} type="modal" />
-    </Modal>
+    </ZModal>
   );
 };

--- a/src/components/MyTimeComponents/Reschedule/Reschedule.tsx
+++ b/src/components/MyTimeComponents/Reschedule/Reschedule.tsx
@@ -1,19 +1,19 @@
-import { Modal, Tooltip } from "antd";
+import { Tooltip } from "antd";
 import { useRecoilState, useRecoilValue } from "recoil";
 import React, { useEffect, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import { darkModeState } from "@src/store";
-import { getDiffInDates, getMonthByIndex } from "@src/utils";
+import { getMonthByIndex } from "@src/utils";
 import SubHeader from "@src/common/SubHeader";
-import { themeState } from "@src/store/ThemeState";
 import { convertDateToDay } from "@src/utils/SchedulerUtils";
 
 import "./Reschedule.scss";
 import { displayReschedule } from "@src/store/TaskState";
-import { ITask, ITaskOfDay } from "@src/Interfaces/Task";
+import { ITask } from "@src/Interfaces/Task";
 import { getFromOutbox } from "@src/api/DumpboxAPI";
 import { IFinalOutputSlot } from "@src/Interfaces/IScheduler";
+import ZModal from "@src/common/ZModal";
 import { rescheduleTaskOnDay } from "@src/api/RescheduledAPI";
 import ScheduledSlots from "./ScheduledSlots";
 
@@ -39,7 +39,6 @@ const Reschedule = () => {
   const [overridenTasks, setOverridenTasks] = useState<IFinalOutputSlot[]>([]);
   const [schedulerOutput, setSchedulerOutput] = useState<{ [key: string]: IFinalOutputSlot[] }>({});
 
-  const theme = useRecoilValue(themeState);
   const darkModeStatus = useRecoilValue(darkModeState);
 
   const getSlots = (start: number, end: number) =>
@@ -91,19 +90,7 @@ const Reschedule = () => {
 
   // console.log(schedulerOutput, selectedDate.toLocaleDateString(), schedulerOutput[selectedDate.toLocaleDateString()]);
   return task ? (
-    <Modal
-      open={!!task}
-      closable={false}
-      footer={null}
-      onCancel={() => setOpen(null)}
-      // eslint-disable-next-line prettier/prettier
-      className={`rescheduleModal popupModal${darkModeStatus ? "-dark" : ""} ${
-        darkModeStatus ? "dark" : "light"
-      }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-      maskStyle={{
-        backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-      }}
-    >
+    <ZModal type="rescheduleModal" open={!!task} onCancel={() => setOpen(null)}>
       <div className="header-title">
         <h4>{task.title}</h4>
       </div>
@@ -175,7 +162,7 @@ const Reschedule = () => {
           Reschedule
         </button>
       </div>
-    </Modal>
+    </ZModal>
   ) : null;
 };
 

--- a/src/pages/ShowFeelingsPage/ShowFeelingTemplate.tsx
+++ b/src/pages/ShowFeelingsPage/ShowFeelingTemplate.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 // @ts-nocheck
 /* eslint-disable react/prop-types */
-import { Modal } from "antd";
 import { useRecoilValue } from "recoil";
 import { useTranslation } from "react-i18next";
 import React, { useState, useEffect } from "react";
@@ -15,8 +14,8 @@ import { IFeelingItem } from "@models";
 import { feelingListType } from "@src/global";
 import { feelingsEmojis } from "@consts/FeelingsList";
 import { ShowFeelingTemplateProps } from "@src/Interfaces/IPages";
+import ZModal from "@src/common/ZModal";
 import { removeFeeling, addFeelingNote, removeFeelingNote } from "@api/FeelingsAPI";
-import { themeState } from "@src/store/ThemeState";
 
 import "@translations/i18n";
 
@@ -33,7 +32,6 @@ export const ShowFeelingTemplate: React.FC<ShowFeelingTemplateProps> = ({
   const [showNotesModal, setShowNotesModal] = useState(-1);
   const [selectedFeelingNote, setSelectedFeelingNote] = useState("");
   const [noteValue, setNoteValue] = useState("");
-  const theme = useRecoilValue(themeState);
 
   const handleInputClose = () => setShowInputModal(-1);
   const handleInputShow = (id) => setShowInputModal(id);
@@ -147,17 +145,10 @@ export const ShowFeelingTemplate: React.FC<ShowFeelingTemplateProps> = ({
             );
           })}
       </div>
-      <Modal
+      <ZModal
         open={showInputModal !== -1}
-        closable={false}
-        footer={null}
         onCancel={() => window.history.back()}
-        className={`${darkModeStatus ? "notes-modal-dark" : ""} popupModal${darkModeStatus ? "-dark" : ""} ${
-          darkModeStatus ? "dark" : "light"
-        }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-        maskStyle={{
-          backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-        }}
+        type={`${darkModeStatus ? "notes-modal-dark" : ""}`}
       >
         <p className="popupModal-title">Want to tell more about it? </p>
         <div>
@@ -191,18 +182,11 @@ export const ShowFeelingTemplate: React.FC<ShowFeelingTemplateProps> = ({
         >
           Save Note
         </button>
-      </Modal>
-      <Modal
+      </ZModal>
+      <ZModal
         open={showNotesModal !== -1}
-        closable={false}
-        footer={null}
         onCancel={() => window.history.back()}
-        className={`notes-modal${darkModeStatus ? "-dark" : ""} popupModal${darkModeStatus ? "-dark" : ""} ${
-          darkModeStatus ? "dark" : "light"
-        }-theme${theme[darkModeStatus ? "dark" : "light"]}`}
-        maskStyle={{
-          backgroundColor: darkModeStatus ? "rgba(0, 0, 0, 0.50)" : "rgba(87, 87, 87, 0.4)",
-        }}
+        className={`notes-modal${darkModeStatus ? "-dark" : ""}`}
       >
         <textarea
           className="show-feeling__note-textarea"
@@ -256,7 +240,7 @@ export const ShowFeelingTemplate: React.FC<ShowFeelingTemplateProps> = ({
             Done
           </button>
         </div>
-      </Modal>
+      </ZModal>
     </>
   );
 };


### PR DESCRIPTION
This pull request introduces the `ZModal` component, which abstracts common props used in our existing antd modal.

- **Common Property Abstraction**: Centralizes shared modal properties to reduce redundancy.

- **Type-Based Customization**: Utilizes a `type` prop for applying distinct styles (can also be used for distinct behaviour), enhancing code clarity.

- **Easy Maintainability**: Simplifies updates and modifications to modal behaviour and appearance, ensuring changes are centralized and consistent.