### PR TITLE
make start goals budget realistic

### DIFF
--- a/src/constants/starterGoals.ts
+++ b/src/constants/starterGoals.ts
@@ -45,7 +45,7 @@ export const starterGoals = [
       afterTime: 9,
       beforeTime: 24,
       timeBudget: {
-        perDay: "1-4",
+        perDay: "0-4",
         perWeek: "1-4",
       },
       on: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
@@ -58,7 +58,7 @@ export const starterGoals = [
       beforeTime: 24,
       timeBudget: {
         perDay: "1-3",
-        perWeek: "1-3",
+        perWeek: "2-3",
       },
       on: ["Sat", "Sun"],
     },


### PR DESCRIPTION
The starter goals were not realistic.  
You can't have 1 hour minimum per day on weekdays - and at the same time have a maximum of 4 per week.  

This PR fixes this.  
I've logged a separate issue #1788  as 0 is not allowed in the budget edit screen yet.