### PR TITLE
Swap font weight of goal timing and options

### DIFF
--- a/src/components/MyTimeComponents/MyTimeline/index.scss
+++ b/src/components/MyTimeComponents/MyTimeline/index.scss
@@ -28,7 +28,7 @@
   }
   .MTL-goalTiming {
     border: none;
-    font-weight: 400;
+    font-weight: 600;
     margin-top: 8px;
     margin-bottom: 0;
     line-height: 16px;
@@ -105,10 +105,10 @@
 .MTL-options > button {
   background: transparent;
   border: 0px;
+  font-weight: 400;
   border-right: 1px solid;
   padding: 0.5em 2em;
   font-size: 0.875rem;
-  font-weight: 600;
 }
 
 .MTL-options > .last-btn {


### PR DESCRIPTION
## Pull Request Description:

Resolves #1764 

## Changes Made:

Toggled the thickness of the MyTime GoalTiming component and MyTime TaskOptions as requested. 

Please review the changes and let me know if any adjustments are to be made.