### PR TITLE
[Issue #1531] || fix darkmode toggle bug

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -113,7 +113,7 @@ const Header: React.FC<IHeader> = ({ title, debounceSearch }) => {
             {isNighttime || darkModeStatus ? (
               <HeaderBtn
                 path={darkModeStatus ? lightModeIcon : darkModeIcon}
-                alt={darkModeStatus ? "light mode" : "dark mode"}
+                alt={`${darkModeStatus ? "light" : "dark"} mode`}
               />
             ) : (
               <HeaderBtn path={darkModeIcon} alt="light mode" />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -110,11 +110,14 @@ const Header: React.FC<IHeader> = ({ title, debounceSearch }) => {
             </h6>
           </div>
           <div className="header-items">
-            {isNighttime && !darkModeStatus ? (
-              <HeaderBtn path={darkModeIcon} alt="dark mode" />
-            ) : !isNighttime && darkModeStatus ? (
-              <HeaderBtn path={lightModeIcon} alt="light mode" />
-            ) : null}
+            {isNighttime || darkModeStatus ? (
+              <HeaderBtn
+                path={darkModeStatus ? lightModeIcon : darkModeIcon}
+                alt={darkModeStatus ? "light mode" : "dark mode"}
+              />
+            ) : (
+              <HeaderBtn path={darkModeIcon} alt="light mode" />
+            )}
             {title === "myGoals" && <HeaderBtn path={searchIcon} alt="zinzen search" />}
             <HeaderBtn path="" alt="zinzen settings" />
           </div>


### PR DESCRIPTION
Description of the Original Issue
As detailed in https://github.com/tijlleenders/ZinZen/issues/1531, the problem appears to be related to the quick toggle feature to switch between dark and light modes. The Icon would disappear depending on what time it was, in the case of the example shown it was when the nighttime logic was active, as I tested it the nighttime logic was not active so the opposite was happening to me  (absence of dark mode icon)


Implemented Solution
I changed the logic to show the opposite icon regardless of what time it was on the user's computer.