### PR TITLE
fix: bug of goal subtext hour/hours not showing

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -242,9 +242,10 @@ export const formatBudgetHrsToText = (hours: string | null) => {
   }
   const parts = hours.split("-").map(Number);
   if (parts.length === 2 && parts[0] === parts[1]) {
-    return `${parts[0]} ${i18next.t("hour", { count: parts[0] })}`;
+    return `${i18next.t(`hourWithCount_${parts[0] <= 1 ? "one" : "other"}`, { count: parts[0] })}`;
   }
-  return `${hours} ${i18next.t("hours")}`;
+
+  return `${parts[0]}-${i18next.t(`hourWithCount_${parts[1] <= 1 ? "one" : "other"}`, { count: parts[1] })}`;
 };
 
 export const calculateDaysLeft = (dueDate: string) => {


### PR DESCRIPTION
closes #1818

Solved the issue where goal subtext hour or hours wasn't showing.

Works for all the supported languages. 

## The Problem:
![Screen Shot 2024-02-04 at 17 20 35](https://github.com/tijlleenders/ZinZen/assets/117534561/69a66988-01b9-42ff-99d5-e2f02362ac42)


## The Solution:
![Screen Shot 2024-02-04 at 17 19 18](https://github.com/tijlleenders/ZinZen/assets/117534561/b5396abd-f92a-4e4e-90ba-b88fd5b32dcb)

