### PR TITLE
solved can't create a goal inside a budget 

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -125,9 +125,6 @@ export function inheritParentProps(newGoal: GoalItem, parentGoal: GoalItem) {
   if (!goal.habit) {
     goal.habit = parentGoal.habit;
   }
-  if (!goal.on) {
-    goal.on = parentGoal.on;
-  }
 
   goal.rootGoalId = parentGoal.rootGoalId;
   goal.typeOfGoal = parentGoal.typeOfGoal;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -122,20 +122,8 @@ export function inheritParentProps(newGoal: GoalItem, parentGoal: GoalItem) {
   if (!goal.due) {
     goal.due = parentGoal.due;
   }
-  if (!(goal.beforeTime || goal.beforeTime === 0)) {
-    goal.beforeTime = parentGoal.beforeTime;
-  }
-  if (!(goal.afterTime || goal.afterTime === 0)) {
-    goal.afterTime = parentGoal.afterTime;
-  }
-  if (!goal.on) {
-    goal.on = parentGoal.on;
-  }
   if (!goal.habit) {
     goal.habit = parentGoal.habit;
-  }
-  if (!goal.timeBudget) {
-    goal.timeBudget = parentGoal.timeBudget;
   }
   if (!goal.on) {
     goal.on = parentGoal.on;


### PR DESCRIPTION
resolves #1839
### Problem 
- When users make a new goal or budget inside another goal or budget without filling in certain details, the new goal or budget would just copy those details from the bigger goal or budget inside.
- At first, it was okay for a new goal or budget to copy details like deadlines and time budgets from the one above it.
- Later, we made two separate things: goals and budgets. Goals needed certain details like the due date and duration but didn't care about other details like time budgets, after time, before time.
- But, when you made a goal inside a budget, it would still copy all the details from the budget, even the ones that didn't make sense for a goal. This made the goal seem like a budget, which we didn't want.

### Solution
- Don't inherit budget-related properties as they are always automatically added during budget creation.