### PR TITLE
fetch hints from server in background while creating/updating GoalItem

### DIFF
--- a/src/helpers/GoalController.ts
+++ b/src/helpers/GoalController.ts
@@ -13,7 +13,6 @@ import {
 } from "@src/api/GoalsAPI";
 import { addHintItem, updateHintItem } from "@src/api/HintsAPI";
 import { restoreUserGoal } from "@src/api/TrashAPI";
-import { IGoalHint } from "@src/models/HintItem";
 import { createGoalObjectFromTags } from "./GoalProcessor";
 import { sendFinalUpdateOnGoal, sendUpdatedGoal } from "./PubSubController";
 


### PR DESCRIPTION
resolves #1883 

This PR addresses an issue where the user interface becomes unresponsive when a user creates or updates a GoalItem with the hint option enabled. Previously, the modal would remain unresponsive until the server responded with hints, which could lead to a suboptimal user experience.

The changes made in this PR ensure that the UI does not freeze while waiting for server responses, thus maintaining a smooth and responsive experience for the user.