### PR TITLE
Implement Scheduled Hints API Calls

### DIFF
--- a/src/api/HintsAPI/ScheduledHintCall.ts
+++ b/src/api/HintsAPI/ScheduledHintCall.ts
@@ -1,0 +1,48 @@
+import { db } from "@src/models";
+import { IGoalHint } from "@src/models/HintItem";
+import { checkForNewGoalHints, getGoalHintItem } from ".";
+import { getGoal, getHintsFromAPI } from "../GoalsAPI";
+
+const manageHintCalls = async (goalId: string) => {
+  const hintItem = await getGoalHintItem(goalId);
+  if (!hintItem) {
+    console.error("No hint item found for the provided ID.");
+    return;
+  }
+
+  const now = new Date();
+  const oneDay = 24 * 60 * 60 * 1000; // One day in milliseconds
+  const oneWeek = 7 * oneDay; // One week in milliseconds
+  const lastCalled = new Date(hintItem.lastCheckedDate);
+
+  const nextCallDelay = hintItem.hintFrequency === "daily" ? oneDay : oneWeek;
+  let shouldCall = false;
+
+  if (now.getTime() - lastCalled.getTime() >= nextCallDelay) {
+    shouldCall = true;
+  }
+
+  if (shouldCall) {
+    const goal = await getGoal(goalId);
+    if (!goal) {
+      return;
+    }
+    const newHints: IGoalHint[] = await getHintsFromAPI(goal);
+    const hasNewHints = await checkForNewGoalHints(goalId, newHints);
+    console.log(`Hints API called for goal ${goalId}. New hints: ${newHints.map((hint) => hint.title)}`);
+
+    await db.hintsCollection.update(goalId, {
+      lastCheckedDate: now,
+      hintFrequency: hasNewHints ? "daily" : "weekly",
+    });
+
+    console.log(`Hints API called for goal ${goalId}. New hints: ${hasNewHints}`);
+  } else {
+    console.log(`No need to call the Hints API for goal ${goalId} yet.`);
+  }
+};
+
+export const scheduledHintCalls = async () => {
+  const goals = await db.hintsCollection.toArray();
+  await Promise.all(goals.map((goal) => manageHintCalls(goal.id)));
+};

--- a/src/api/HintsAPI/index.ts
+++ b/src/api/HintsAPI/index.ts
@@ -28,7 +28,13 @@ export const addHintItem = async (goalId: string, hint: boolean, goalHints: IGoa
     }
     return hintItem;
   });
-  const hintObject = { id: goalId, hint, goalHints: updatedHintsWithId };
+  const hintObject = {
+    id: goalId,
+    hint,
+    goalHints: updatedHintsWithId,
+    lastCheckedDate: new Date().toISOString(),
+    hintFrequency: "daily",
+  };
   await db
     .transaction("rw", db.hintsCollection, async () => {
       await db.hintsCollection.add(hintObject);

--- a/src/hooks/useApp.tsx
+++ b/src/hooks/useApp.tsx
@@ -134,14 +134,13 @@ function useApp() {
 
   // Check for missed hint calls
   useEffect(() => {
-    (async () => {
-      try {
-        await scheduledHintCalls();
+    scheduledHintCalls()
+      .then(() => {
         console.log("Checked for missed hint calls.");
-      } catch (error) {
+      })
+      .catch((error) => {
         console.error("Failed to check for missed hint calls:", error);
-      }
-    })();
+      });
   }, []);
 
   useEffect(() => {

--- a/src/hooks/useApp.tsx
+++ b/src/hooks/useApp.tsx
@@ -12,6 +12,7 @@ import { handleIncomingChanges } from "@src/helpers/InboxProcessor";
 import { getContactSharedGoals, shareGoalWithContact } from "@src/services/contact.service";
 import { updateAllUnacceptedContacts, getContactByRelId, clearTheQueue } from "@src/api/ContactsAPI";
 import { useSetRecoilState, useRecoilValue, useRecoilState } from "recoil";
+import { scheduledHintCalls } from "@src/api/HintsAPI/ScheduledHintCall";
 
 const langFromStorage = localStorage.getItem("language")?.slice(1, -1);
 const exceptionRoutes = ["/", "/invest", "/feedback", "/donate"];
@@ -130,6 +131,18 @@ function useApp() {
   useEffect(() => {
     localStorage.setItem("confirmationState", JSON.stringify(confirmationState));
   }, [confirmationState]);
+
+  // Check for missed hint calls
+  useEffect(() => {
+    (async () => {
+      try {
+        await scheduledHintCalls();
+        console.log("Checked for missed hint calls.");
+      } catch (error) {
+        console.error("Failed to check for missed hint calls:", error);
+      }
+    })();
+  }, []);
 
   useEffect(() => {
     const checkDevMode = async () => {

--- a/src/models/HintItem.ts
+++ b/src/models/HintItem.ts
@@ -10,7 +10,6 @@ export interface HintItem {
   hint: boolean;
   goalHints: IGoalHint[];
   lastCheckedDate: string;
-  newHintsPresent: boolean;
   hintFrequency: string;
 }
 

--- a/src/models/HintItem.ts
+++ b/src/models/HintItem.ts
@@ -10,7 +10,7 @@ export interface HintItem {
   hint: boolean;
   goalHints: IGoalHint[];
   lastCheckedDate: string;
-  hintFrequency: string;
+  nextCheckDate: string;
 }
 
 export interface IHintRequestBody {

--- a/src/models/HintItem.ts
+++ b/src/models/HintItem.ts
@@ -9,6 +9,9 @@ export interface HintItem {
   id: string;
   hint: boolean;
   goalHints: IGoalHint[];
+  lastCheckedDate: string;
+  newHintsPresent: boolean;
+  hintFrequency: string;
 }
 
 export interface IHintRequestBody {

--- a/src/models/db.ts
+++ b/src/models/db.ts
@@ -11,7 +11,7 @@ import { TrashItem } from "./TrashItem";
 import { HintItem } from "./HintItem";
 import { ImpossibleGoalItem } from "./ImpossibleGoalItem";
 
-export const dexieVersion = 19;
+export const dexieVersion = 20;
 
 const currentVersion = Number(localStorage.getItem("dexieVersion") || dexieVersion);
 localStorage.setItem("dexieVersion", `${dexieVersion}`);
@@ -60,7 +60,7 @@ export class ZinZenDB extends Dexie {
         partnersCollection: null,
         goalTrashCollection:
           "id, category, deletedAt, title, duration, sublist, habit, on, start, due, afterTime, beforeTime, createdAt, parentGoalId, archived, participants, goalColor, language, link, rootGoalId, timeBudget, typeOfGoal",
-        hintsCollection: "id, hint, goalHints",
+        hintsCollection: "id, hint, goalHints, lastCheckedDate, hintFrequency",
         impossibleGoalsCollection: "goalId, goalTitle",
       })
       .upgrade((trans) => {

--- a/src/models/db.ts
+++ b/src/models/db.ts
@@ -60,7 +60,7 @@ export class ZinZenDB extends Dexie {
         partnersCollection: null,
         goalTrashCollection:
           "id, category, deletedAt, title, duration, sublist, habit, on, start, due, afterTime, beforeTime, createdAt, parentGoalId, archived, participants, goalColor, language, link, rootGoalId, timeBudget, typeOfGoal",
-        hintsCollection: "id, hint, goalHints, lastCheckedDate, hintFrequency",
+        hintsCollection: "id, hint, goalHints, lastCheckedDate, nextCheckDate",
         impossibleGoalsCollection: "goalId, goalTitle",
       })
       .upgrade((trans) => {
@@ -190,7 +190,7 @@ export class ZinZenDB extends Dexie {
           console.log("processing updates for 20th version");
           const hintsCollection = trans.table("hintsCollection");
           hintsCollection.toCollection().modify((hint: HintItem) => {
-            hint.hintFrequency = "daily";
+            hint.nextCheckDate = new Date().toISOString();
             hint.lastCheckedDate = new Date().toISOString();
           });
         }

--- a/src/models/db.ts
+++ b/src/models/db.ts
@@ -186,6 +186,14 @@ export class ZinZenDB extends Dexie {
               goal.category = goal.afterTime || goal.beforeTime ? "Budget" : goal.duration ? "Standard" : "Cluster";
             });
         }
+        if (currentVersion < 20) {
+          console.log("processing updates for 20th version");
+          const hintsCollection = trans.table("hintsCollection");
+          hintsCollection.toCollection().modify((hint: HintItem) => {
+            hint.hintFrequency = "daily";
+            hint.lastCheckedDate = new Date().toISOString();
+          });
+        }
       });
   }
 }


### PR DESCRIPTION
### Changes Made:

- New Fields for Tracking Hints
  **lastCheckDate:** This is a new field that records when we last checked for hints for each goal.
  **nextChecktDate:** This field stores string value (daily or weekly) that tells us whether to check for new hints daily or weekly.

- Updates to the Hints API: 
   Changed current hints API to use these new fields. 
 
- Checking for New Hints:
         Added a new function that looks for new hints. It checks the hints we just got against the hints we already know to see if there are any changes. Then it updates the nextCheckDate field to now+1day if new hint is found - else the value is set to now+1week. 

 - Automatic Hint Checking Schedule:
        Set up a new system that decides when to check for hints based on whether we found new hints recently. If we find new hints, we'll check again the next day. If not, we'll check again in a week. 

resolves #1824 