### PR TITLE
conditionally render task end times

### DIFF
--- a/src/components/MyTimeComponents/MyTimeline/GoalTiming.tsx
+++ b/src/components/MyTimeComponents/MyTimeline/GoalTiming.tsx
@@ -4,9 +4,10 @@ interface GoalTimingProps {
   startTime: string | null;
   endTime: string | null;
   showTaskOptions: boolean;
+  displayEndTime: boolean;
 }
 
-export const GoalTiming: React.FC<GoalTimingProps> = ({ startTime, endTime, showTaskOptions }) => {
+export const GoalTiming: React.FC<GoalTimingProps> = ({ startTime, endTime, showTaskOptions, displayEndTime }) => {
   const renderTime = (time: string, className: string) => (
     <p className={className}>
       {parseInt(time, 10)} <sup>00</sup>
@@ -16,7 +17,7 @@ export const GoalTiming: React.FC<GoalTimingProps> = ({ startTime, endTime, show
   return (
     <div className="MTL-goalTiming">
       {startTime && renderTime(startTime, "MTL-startTime")}
-      {endTime && showTaskOptions && renderTime(endTime, "MTL-endTime")}
+      {endTime && displayEndTime && showTaskOptions && renderTime(endTime, "MTL-endTime")}
     </div>
   );
 };

--- a/src/components/MyTimeComponents/MyTimeline/MyTimeline.tsx
+++ b/src/components/MyTimeComponents/MyTimeline/MyTimeline.tsx
@@ -153,9 +153,12 @@ export const MyTimeline: React.FC<MyTimelineProps> = ({ day, myTasks, taskDetail
 
   return (
     <div className="MTL-display" style={{ paddingTop: `${myTasks.scheduled.length > 0 ? "" : "1.125rem"}` }}>
-      {myTasks.scheduled.map((task) => {
+      {myTasks.scheduled.map((task, index) => {
         const startTime = task.start ? task.start.split("T")[1].slice(0, 2) : null;
         const endTime = task.deadline ? task.deadline.split("T")[1].slice(0, 2) : null;
+        const nextTask = myTasks.scheduled[index + 1];
+        const nextStartTime = nextTask ? nextTask.start.split("T")[1].slice(0, 2) : null;
+        const displayEndTime = endTime !== nextStartTime;
         const markDone = !!taskDetails[task.goalid]?.completedTodayIds.includes(task.taskid);
         const showTaskOptions = displayOptionsIndex === task.taskid;
         return (
@@ -178,7 +181,12 @@ export const MyTimeline: React.FC<MyTimelineProps> = ({ day, myTasks, taskDetail
             }}
           >
             <div className="MTL-color-block" style={{ backgroundColor: `${task.goalColor}` }} />
-            <GoalTiming startTime={startTime} endTime={endTime} showTaskOptions={showTaskOptions} />
+            <GoalTiming
+              startTime={startTime}
+              endTime={endTime}
+              showTaskOptions={showTaskOptions}
+              displayEndTime={displayEndTime}
+            />
             <div style={{ flex: 1 }}>
               <div style={{ display: "flex", position: "relative" }}>
                 <div style={{ marginLeft: "11px", color: `${task.goalColor}` }}>


### PR DESCRIPTION
- **Introduced displayEndTime Prop**: Added a new boolean prop to control the display of the ending time in the GoalTiming component.
- **Conditional Rendering in GoalTiming:** Adjusted rendering to show the end time only if displayEndTime and showTaskOptions are true.
- **Comparison Logic in MyTimeline:** Added logic to determine if the end time should be displayed by comparing it with the next task's start time.

resolves #1794 
