### PR TITLE
fix: lint script not working locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "preview": "vite preview",
     "test": "jest --verbose ./src/__tests__",
     "cypresstest": "cypress run",
-    "lint": "eslint .",
+    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --quiet",
     "lint-fix": "eslint ./ --fix",
     "format": "prettier --write .",
     "format-all": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "preview": "vite preview",
     "test": "jest --verbose ./src/__tests__",
     "cypresstest": "cypress run",
-    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --quiet",
+    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint-fix": "eslint ./ --fix",
     "format": "prettier --write .",
     "format-all": "prettier --write .",


### PR DESCRIPTION
The earlier `npm run lint` script was not working properly. Fixed it by updating the command.