### PR TITLE
Goal title colon bug fixed

### DIFF
--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -21,6 +21,9 @@ i18n
   .init({
     fallbackLng: "en",
 
+    nsSeparator: false,
+    keySeparator: false,
+
     returnEmptyString: false,
     resources: {
       en: {


### PR DESCRIPTION
Resolves #1891 

The issue was with **i18next** module. Added the following config in the configuration file of i18next, to resolve the issue.

`nsSeparator: false,
keySeparator: false`