### PR TITLE
Fix manifest

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,8 +33,8 @@ export default defineConfig({
       srcDir: "src/service-worker",
       filename: "service-worker.ts",
       manifest: {
-        short_name: "zinzen",
-        name: "zinzen-me.zinzen",
+        short_name: "ZinZen",
+        name: "ZinZen.me",
         icons: [
           {
             src: "pwa-192x192.png",


### PR DESCRIPTION
When trying to publish web app to open-store.io I changed the manifest. This was not necessary and actually gives the wrong name on app startup.

Fixed with this commit.