### PR TITLE
fix: show scrollbar on overflow

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -4,6 +4,30 @@ div::-webkit-scrollbar {
   display: none;
 }
 
+.mainDiv::-webkit-scrollbar {
+  display: block;
+  width: 8px;
+}
+
+.mainDiv::-webkit-scrollbar-thumb {
+  background-color: rgba(140, 140, 140, 0.5);
+  border-radius: 4px;
+}
+
+.mainDiv {
+  max-width: 600px;
+  min-width: 236;
+  overflow: scroll;
+  scroll-behavior: smooth;
+  width: 100%;
+  margin-top: 60px;
+  margin-bottom: 7px;
+  height: calc(100vh - 112px);
+  overflow-y: scroll;
+  padding-bottom: 100px;
+  z-index: 0;
+}
+
 img {
   width: 24px;
   height: 24px;

--- a/src/global.scss
+++ b/src/global.scss
@@ -4,28 +4,15 @@ div::-webkit-scrollbar {
   display: none;
 }
 
-.mainDiv::-webkit-scrollbar {
+/* App Layout */
+.appLayout::-webkit-scrollbar {
   display: block;
   width: 8px;
 }
 
-.mainDiv::-webkit-scrollbar-thumb {
+.appLayout::-webkit-scrollbar-thumb {
   background-color: rgba(140, 140, 140, 0.5);
   border-radius: 4px;
-}
-
-.mainDiv {
-  max-width: 600px;
-  min-width: 236;
-  overflow: scroll;
-  scroll-behavior: smooth;
-  width: 100%;
-  margin-top: 60px;
-  margin-bottom: 7px;
-  height: calc(100vh - 112px);
-  overflow-y: scroll;
-  padding-bottom: 100px;
-  z-index: 0;
 }
 
 img {

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -8,20 +8,7 @@ import Header from "../components/Header/Header";
 const AppLayout: React.FC<AppLayoutProps> = ({ children, title, debounceSearch }) => (
   <>
     <Header title={title} debounceSearch={debounceSearch} />
-    <div
-      style={{
-        maxWidth: 600,
-        minWidth: 236,
-        overflow: "scroll",
-        width: "100%",
-        marginTop: 60,
-        height: "calc(100vh - 112px)",
-        position: "sticky",
-        paddingBottom: 150,
-      }}
-    >
-      {children}
-    </div>
+    <div className="mainDiv">{children}</div>
     <BottomNavbar title={title} />
   </>
 );

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -8,7 +8,23 @@ import Header from "../components/Header/Header";
 const AppLayout: React.FC<AppLayoutProps> = ({ children, title, debounceSearch }) => (
   <>
     <Header title={title} debounceSearch={debounceSearch} />
-    <div className="mainDiv">{children}</div>
+    <div
+      style={{
+        maxWidth: 600,
+        minWidth: 236,
+        overflow: "scroll",
+        scrollBehavior: "smooth",
+        width: "100%",
+        marginTop: 60,
+        marginBottom: 7,
+        height: "calc(100vh - 112px)",
+        paddingBottom: 100,
+        zIndex: 0,
+      }}
+      className="appLayout"
+    >
+      {children}
+    </div>
     <BottomNavbar title={title} />
   </>
 );


### PR DESCRIPTION
Added scrollbar on goals section. User can now scroll through the content. Also, I've added z-index to properly show the footer on overflow.

Closes #2057 

![image](https://github.com/user-attachments/assets/549b5209-99a8-4155-8fde-9dfa6818e922)
