### PR TITLE
restrict archived suggestions to parent goals only and fix subgoal render problem

### DIFF
--- a/src/api/GoalsAPI/index.ts
+++ b/src/api/GoalsAPI/index.ts
@@ -353,27 +353,29 @@ export const addHintGoaltoMyGoals = async (goal: GoalItem) => {
   ]);
 };
 
-export const fetchArchivedGoalByTitle = async (goalId: string, parentGoalId: string) => {
-  if (goalId.trim() === "") {
+export const fetchArchivedDescendantGoalByTitle = async (goalTitle: string, parentGoalId: string) => {
+  if (!goalTitle.trim()) {
     return [];
   }
 
-  const lowerCaseValue = goalId.toLowerCase();
+  const searchTitle = goalTitle.toLowerCase();
 
   const getAllChildrenGoals = async (id: string): Promise<GoalItem[]> => {
     const directChildren = await getChildrenGoals(id);
 
-    const allChildren = await Promise.all(
+    const allDescendantGoals = await Promise.all(
       directChildren.map(async (child) => {
         const grandchildren = await getAllChildrenGoals(child.id);
         return [child, ...grandchildren];
       }),
     );
 
-    return allChildren.flat();
+    return allDescendantGoals.flat();
   };
 
-  const allChildren = await getAllChildrenGoals(parentGoalId);
+  const allDescendantGoals = await getAllChildrenGoals(parentGoalId);
 
-  return allChildren.filter((goal) => goal.archived === "true" && goal.title.toLowerCase().startsWith(lowerCaseValue));
+  return allDescendantGoals.filter(
+    (goal) => goal.archived === "true" && goal.title.toLowerCase().startsWith(searchTitle),
+  );
 };

--- a/src/api/GoalsAPI/index.ts
+++ b/src/api/GoalsAPI/index.ts
@@ -362,14 +362,15 @@ export const fetchArchivedGoalByTitle = async (goalId: string, parentGoalId: str
 
   const getAllChildrenGoals = async (id: string): Promise<GoalItem[]> => {
     const directChildren = await getChildrenGoals(id);
-    let allChildren = [...directChildren];
 
-    for (const child of directChildren) {
-      const grandchildren = await getAllChildrenGoals(child.id);
-      allChildren = allChildren.concat(grandchildren);
-    }
+    const allChildren = await Promise.all(
+      directChildren.map(async (child) => {
+        const grandchildren = await getAllChildrenGoals(child.id);
+        return [child, ...grandchildren];
+      }),
+    );
 
-    return allChildren;
+    return allChildren.flat();
   };
 
   const allChildren = await getAllChildrenGoals(parentGoalId);

--- a/src/components/GoalsComponents/GoalConfigModal/components/ArchivedAutoComplete.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/components/ArchivedAutoComplete.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { GoalItem } from "@src/models/GoalItem";
 import AutocompleteComponent from "@components/GoalsComponents/GoalConfigModal/components/AutoComplete";
-import { fetchArchivedGoalByTitle } from "@src/api/GoalsAPI";
+import { fetchArchivedDescendantGoalByTitle } from "@src/api/GoalsAPI";
 import { useParentGoalContext } from "@src/contexts/parentGoal-context";
 
 interface ArchivedAutoCompleteProps {
@@ -26,7 +26,7 @@ const ArchivedAutoComplete: React.FC<ArchivedAutoCompleteProps> = ({
 
   const searchArchivedGoals = useCallback(
     async (value: string) => {
-      const goals = await fetchArchivedGoalByTitle(value, parentGoalId);
+      const goals = await fetchArchivedDescendantGoalByTitle(value, parentGoalId);
       setFilteredGoals(goals);
     },
     [parentGoalId],

--- a/src/components/GoalsComponents/GoalConfigModal/components/ArchivedAutoComplete.tsx
+++ b/src/components/GoalsComponents/GoalConfigModal/components/ArchivedAutoComplete.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from "react";
 import { GoalItem } from "@src/models/GoalItem";
 import AutocompleteComponent from "@components/GoalsComponents/GoalConfigModal/components/AutoComplete";
 import { fetchArchivedGoalByTitle } from "@src/api/GoalsAPI";
+import { useParentGoalContext } from "@src/contexts/parentGoal-context";
 
 interface ArchivedAutoCompleteProps {
   onGoalSelect: (goal: GoalItem) => void;
@@ -17,11 +18,19 @@ const ArchivedAutoComplete: React.FC<ArchivedAutoCompleteProps> = ({
   placeholder,
 }) => {
   const [filteredGoals, setFilteredGoals] = useState<GoalItem[]>([]);
+  const {
+    parentData: { parentGoal },
+  } = useParentGoalContext();
 
-  const searchArchivedGoals = useCallback(async (value: string) => {
-    const goals = await fetchArchivedGoalByTitle(value);
-    setFilteredGoals(goals);
-  }, []);
+  const parentGoalId = parentGoal ? parentGoal.id : "root";
+
+  const searchArchivedGoals = useCallback(
+    async (value: string) => {
+      const goals = await fetchArchivedGoalByTitle(value, parentGoalId);
+      setFilteredGoals(goals);
+    },
+    [parentGoalId],
+  );
 
   const handleInputChange = useCallback(
     (value: string) => {

--- a/src/contexts/parentGoal-context.tsx
+++ b/src/contexts/parentGoal-context.tsx
@@ -70,7 +70,7 @@ export const ParentGoalProvider = ({ children }: { children: ReactNode }) => {
   }, [parentId]);
 
   useEffect(() => {
-    if (suggestedGoal === null) {
+    if (!suggestedGoal) {
       init();
     }
   }, [suggestedGoal]);

--- a/src/contexts/parentGoal-context.tsx
+++ b/src/contexts/parentGoal-context.tsx
@@ -3,6 +3,7 @@ import { getSharedWMChildrenGoals, getSharedWMGoalById } from "@src/api/SharedWM
 import { GoalItem } from "@src/models/GoalItem";
 import { lastAction } from "@src/store";
 import { allowAddingBudgetGoal } from "@src/store/GoalsState";
+import { suggestedGoalState } from "@src/store/SuggestedGoalState";
 import React, { ReactNode, createContext, useContext, useEffect, useMemo, useReducer } from "react";
 import { useParams } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
@@ -46,6 +47,7 @@ export const ParentGoalProvider = ({ children }: { children: ReactNode }) => {
   const setAllowBudgetGoal = useSetRecoilState(allowAddingBudgetGoal);
   const [parentData, dispatch] = useReducer(parentGoalReducer, initialState);
   const isPartnerModeActive = !!partnerId;
+  const suggestedGoal = useRecoilValue(suggestedGoalState);
 
   async function init() {
     if (parentId !== "root") {
@@ -66,6 +68,12 @@ export const ParentGoalProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     init();
   }, [parentId]);
+
+  useEffect(() => {
+    if (suggestedGoal === null) {
+      init();
+    }
+  }, [suggestedGoal]);
 
   useEffect(() => {
     if (action === "goalArchived") {

--- a/src/hooks/useGoalActions.tsx
+++ b/src/hooks/useGoalActions.tsx
@@ -92,20 +92,11 @@ const useGoalActions = () => {
       // Comparing hashes of the old (activeGoal) and updated (goal) versions to check if the goal has changed
       await modifyGoal(goal.id, goal, [...ancestors, goal.id], updatedHintOption);
       setLastAction("goalUpdated");
-      if (suggestedGoal) {
-        setShowToast({
-          open: true,
-          message: "Goal (re)created!",
-          extra: "",
-        });
-      } else {
-        setShowToast({
-          open: true,
-          message: "Goal updated!",
-          extra: "",
-        });
-      }
-
+      setShowToast({
+        open: true,
+        message: suggestedGoal ? "Goal (re)created!" : "Goal updated!",
+        extra: "",
+      });
       addGoalSound.play();
     }
   };

--- a/src/hooks/useGoalActions.tsx
+++ b/src/hooks/useGoalActions.tsx
@@ -10,7 +10,7 @@ import { useLocation, useParams } from "react-router-dom";
 import pageCrumplingSound from "@assets/page-crumpling-sound.mp3";
 import plingSound from "@assets/pling.mp3";
 
-import { useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { shareGoalWithContact } from "@src/services/contact.service";
 import { addToSharingQueue } from "@src/api/ContactsAPI";
 import { ILocationState } from "@src/Interfaces";
@@ -18,6 +18,7 @@ import { hashObject } from "@src/utils";
 import { useActiveGoalContext } from "@src/contexts/activeGoal-context";
 import { removeBackTicks } from "@src/utils/patterns";
 import { getGoalHintItem } from "@src/api/HintsAPI";
+import { suggestedGoalState } from "@src/store/SuggestedGoalState";
 
 const pageCrumple = new Audio(pageCrumplingSound);
 const addGoalSound = new Audio(plingSound);
@@ -31,6 +32,7 @@ const useGoalActions = () => {
   const subGoalsHistory = state?.goalsHistory || [];
   const ancestors = subGoalsHistory.map((ele) => ele.goalID);
   const { goal: activeGoal } = useActiveGoalContext();
+  const suggestedGoal = useRecoilValue(suggestedGoalState);
 
   const setShowToast = useSetRecoilState(displayToast);
 
@@ -90,11 +92,20 @@ const useGoalActions = () => {
       // Comparing hashes of the old (activeGoal) and updated (goal) versions to check if the goal has changed
       await modifyGoal(goal.id, goal, [...ancestors, goal.id], updatedHintOption);
       setLastAction("goalUpdated");
-      setShowToast({
-        open: true,
-        message: "Goal updated!",
-        extra: "",
-      });
+      if (suggestedGoal) {
+        setShowToast({
+          open: true,
+          message: "Goal (re)created!",
+          extra: "",
+        });
+      } else {
+        setShowToast({
+          open: true,
+          message: "Goal updated!",
+          extra: "",
+        });
+      }
+
       addGoalSound.play();
     }
   };

--- a/src/hooks/useGoalStore.tsx
+++ b/src/hooks/useGoalStore.tsx
@@ -13,14 +13,12 @@ const useGoalStore = () => {
   const openEditMode = (goal: GoalItem, customState?: ILocationState) => {
     const prefix = `${partnerId ? `/partners/${partnerId}/` : "/"}goals`;
 
-    const newState = {
-      ...location.state,
-      goalType: goal.category === "Budget" ? "Budget" : "Goal",
-      ...customState,
-    };
-
     navigate(`${prefix}/${goal.parentGoalId}/${goal.id}?type=${goal.category}&mode=edit`, {
-      state: newState,
+      state: {
+        ...location.state,
+        goalType: goal.category === "Budget" ? "Budget" : "Goal",
+        ...customState,
+      },
       replace: true,
     });
   };

--- a/src/hooks/useGoalStore.tsx
+++ b/src/hooks/useGoalStore.tsx
@@ -1,7 +1,8 @@
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { GoalItem, TGoalCategory } from "@src/models/GoalItem";
+import { GoalItem } from "@src/models/GoalItem";
 import { displayConfirmation } from "@src/store";
+import { ILocationState } from "@src/Interfaces";
 
 const useGoalStore = () => {
   const { partnerId } = useParams();
@@ -9,13 +10,17 @@ const useGoalStore = () => {
   const location = useLocation();
   const showConfirmation = useRecoilValue(displayConfirmation);
 
-  const openEditMode = (goal: GoalItem) => {
+  const openEditMode = (goal: GoalItem, customState?: ILocationState) => {
     const prefix = `${partnerId ? `/partners/${partnerId}/` : "/"}goals`;
+
+    const newState = {
+      ...location.state,
+      goalType: goal.category === "Budget" ? "Budget" : "Goal",
+      ...customState,
+    };
+
     navigate(`${prefix}/${goal.parentGoalId}/${goal.id}?type=${goal.category}&mode=edit`, {
-      state: {
-        ...location.state,
-        goalType: goal.category === "Budget" ? "Budget" : "Goal",
-      },
+      state: newState,
       replace: true,
     });
   };


### PR DESCRIPTION
Fixed:

- only show suggestion of archived child goals of a parent
- fix re-render problem
- show different toast msg when suggested goal is added.