### PR TITLE
fix: toast not opening correctly for some parts in app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,9 +70,7 @@ const App = () => {
     });
 
     if (!clickedInside) {
-      setTimeout(() => {
-        api.destroy();
-      }, 0);
+      api.destroy();
     }
   };
 


### PR DESCRIPTION
resolves #2115 

The issue was caused due to toast destroy method wrapped inside setTimeout which caused racing conditions. Removed the setTimeout and directly called the destroy method on function call only.